### PR TITLE
Canadian Airports Excluded from International Metar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build Client
 
 on:
   push:
-    tags:
-      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build Client
 
 on:
   push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/Vatis.Client/MetarParser/Entity/DecodedMetar.cs
+++ b/Vatis.Client/MetarParser/Entity/DecodedMetar.cs
@@ -69,7 +69,7 @@ namespace MetarDecoder
         /// </summary>
         public string ICAO { get; set; } = string.Empty;
 
-        public bool IsInternational => !ICAO.StartsWith("K") && !ICAO.StartsWith("P");
+        public bool IsInternational => !ICAO.StartsWith("K") && !ICAO.StartsWith("P") && !ICAO.StartsWith("C");
 
         /// <summary>
         /// Day of this observation


### PR DESCRIPTION
Excludes canadian airpots (starting with C) from being decoded as 'international'. We use a similar ATIS as the FAA. 

#15 