### PR TITLE
Moved VersionCheck to Profile List

### DIFF
--- a/Vatis.Client/MainForm.cs
+++ b/Vatis.Client/MainForm.cs
@@ -27,9 +27,6 @@ namespace Vatsim.Vatis.Client
         [EventPublication(EventTopics.SessionEnded)]
         public event EventHandler<EventArgs> RaiseSessionEnded;
 
-        [EventPublication(EventTopics.PerformVersionCheck)]
-        public event EventHandler<EventArgs> RaisePerformVersionCheck;
-
         [EventPublication(EventTopics.RefreshMinifiedWindow)]
         public event EventHandler<EventArgs> RefreshMinifiedWindow;
 
@@ -147,8 +144,6 @@ namespace Vatsim.Vatis.Client
             {
                 mAppConfig.CurrentComposite = (atisTabs.TabPages[0].Tag as AtisComposite);
             }
-
-            RaisePerformVersionCheck?.Invoke(this, EventArgs.Empty);
         }
 
         protected override void OnMove(EventArgs e)

--- a/Vatis.Client/ProfileList.cs
+++ b/Vatis.Client/ProfileList.cs
@@ -14,7 +14,6 @@ namespace Vatsim.Vatis.Client
 {
     internal partial class ProfileList : Form
     {
-
         [EventPublication(EventTopics.PerformVersionCheck)]
         public event EventHandler<EventArgs> RaisePerformVersionCheck;
 

--- a/Vatis.Client/ProfileList.cs
+++ b/Vatis.Client/ProfileList.cs
@@ -14,6 +14,10 @@ namespace Vatsim.Vatis.Client
 {
     internal partial class ProfileList : Form
     {
+
+        [EventPublication(EventTopics.PerformVersionCheck)]
+        public event EventHandler<EventArgs> RaisePerformVersionCheck;
+
         private readonly IEventBroker mEventBroker;
         private readonly IUserInterface mUserInterface;
         private readonly IAppConfig mAppConfig;
@@ -87,6 +91,8 @@ namespace Vatsim.Vatis.Client
             lblVersion.Text = $"Version { Application.ProductVersion }";
 
             RefreshList();
+
+            RaisePerformVersionCheck?.Invoke(this, EventArgs.Empty);
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)


### PR DESCRIPTION
Moves the VersionCheck to the profile list form load event removing the requirement of loading a profile for version check to occur.