### PR TITLE
Improve Composite Load Times

### DIFF
--- a/Vatis.Client/Common/SystemIdentifier.cs
+++ b/Vatis.Client/Common/SystemIdentifier.cs
@@ -6,10 +6,15 @@ namespace Vatsim.Vatis.Client.Common
 {
     public static class SystemIdentifier
     {
+        private static string mSystemDriveVolumeId = "";
         public static string GetSystemDriveVolumeId()
         {
-            string environmentVariable = Environment.GetEnvironmentVariable("SystemDrive");
-            return int.Parse(new ManagementObject($"win32_logicaldisk.deviceid=\"{environmentVariable.ToUpper()}\"").Properties["VolumeSerialNumber"].Value.ToString(), NumberStyles.HexNumber).ToString();
+            if (mSystemDriveVolumeId == "")
+            {
+                string environmentVariable = Environment.GetEnvironmentVariable("SystemDrive");
+                mSystemDriveVolumeId = int.Parse(new ManagementObject($"win32_logicaldisk.deviceid=\"{environmentVariable.ToUpper()}\"").Properties["VolumeSerialNumber"].Value.ToString(), NumberStyles.HexNumber).ToString();
+            }
+            return mSystemDriveVolumeId;
         }
     }
 }


### PR DESCRIPTION
GetSystemDriveVolumeId is being called every time you create a new Connection object. 
This value should remain unchanged during runtime and calling it for multiple composites resulted in significant loading times with a large number of composites.

I can't think of a reason why you would need to generate this value multiple times so caching is seems like the right thing to do.