### PR TITLE
Added sorting to tab control

### DIFF
--- a/Vatis.Client/Core/Constants.cs
+++ b/Vatis.Client/Core/Constants.cs
@@ -3,6 +3,6 @@
     public static class Constants
     {
         public const int MAX_CONNECTIONS = 4;
-        public const int MAX_COMPOSITES = 15;
+        public const int MAX_COMPOSITES = 30;
     }
 }

--- a/Vatis.Client/Core/Constants.cs
+++ b/Vatis.Client/Core/Constants.cs
@@ -3,6 +3,6 @@
     public static class Constants
     {
         public const int MAX_CONNECTIONS = 4;
-        public const int MAX_COMPOSITES = 30;
+        public const int MAX_COMPOSITES = 50;
     }
 }

--- a/Vatis.Client/MainForm.cs
+++ b/Vatis.Client/MainForm.cs
@@ -1,4 +1,4 @@
-﻿using Appccelerate.EventBroker;
+using Appccelerate.EventBroker;
 using Appccelerate.EventBroker.Handlers;
 using System;
 using System.Collections.Generic;
@@ -611,6 +611,8 @@ namespace Vatsim.Vatis.Client
                     mConnections.Add(connection);
                 }
             }
+
+            atisTabs.Sort();
         }
 
         private void atisTabs_SelectedIndexChanged(object sender, EventArgs e)

--- a/Vatis.Client/UI/AtisTabPage.cs
+++ b/Vatis.Client/UI/AtisTabPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms;
 using Vatsim.Vatis.Client.Config;
 using Vatsim.Vatis.Client.Network;
@@ -52,6 +53,18 @@ namespace Vatsim.Vatis.Client.UI
                 mAlternateColor = !mAlternateColor;
                 Parent?.Invalidate();
             };
+        }
+    }
+
+
+    internal class TabPageComparer : IComparer<AtisTabPage>
+    {
+        public int Compare(AtisTabPage x, AtisTabPage y)
+        {
+            if (x.Connection.IsConnected && !y.Connection.IsConnected) return -1;
+            if (!x.Connection.IsConnected && y.Connection.IsConnected) return 1;
+
+            return string.Compare(x.Composite.Identifier, y.Composite.Identifier);
         }
     }
 }

--- a/Vatis.Client/UI/Tabs.cs
+++ b/Vatis.Client/UI/Tabs.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using Vatsim.Vatis.Client.Config;
 
@@ -112,5 +113,14 @@ namespace Vatsim.Vatis.Client.UI
                 g.DrawString(tabPage.CompositeMeta.AtisLetter, Font, brush, layoutRect, stringFormat);
             }
         }
+
+        public void Sort()
+        {
+            var tabList = TabPages.Cast<AtisTabPage>().ToList();
+            tabList.Sort(new TabPageComparer());
+            TabPages.Clear();
+            TabPages.AddRange(tabList.ToArray());
+        }
+
     }
 }


### PR DESCRIPTION
For the event where not all composites are connected, the connected composites will be sorted first and sorted by identifier followed by the rest of the composites. 

The sort function first checks if only one of the composites is connected and puts the connected composite first.
If they are both not connected or both connected it will then sort by identifier.

I also increased the limit to 50 composites which allows for adding every airport in an ARTCC to one profile for ease of access (I don't believe any ARTCC has more than 50 so that is a good number to work with imo)

With the loading time improvements in #69 I don't see a reason to limit the max composites since the UI can handle virtually any amount.