### PR TITLE
MiniDisplay "OnTop" now follows settings checkmark

### DIFF
--- a/Vatis.Client/MiniDisplay.cs
+++ b/Vatis.Client/MiniDisplay.cs
@@ -158,13 +158,16 @@ namespace Vatsim.Vatis.Client
         {
             base.OnLoad(e);
 
-            TopMost = true;
-
             if (mAppConfig.MiniDisplayWindowProperties == null)
             {
                 mAppConfig.MiniDisplayWindowProperties = new WindowProperties();
                 mAppConfig.MiniDisplayWindowProperties.Location = ScreenUtils.CenterOnScreen(this);
                 mAppConfig.SaveConfig();
+            }
+
+            if (mAppConfig.MiniDisplayWindowProperties.TopMost != mAppConfig.WindowProperties.TopMost)
+            {
+                mAppConfig.MiniDisplayWindowProperties.TopMost = mAppConfig.WindowProperties.TopMost;
             }
 
             ScreenUtils.ApplyWindowProperties(mAppConfig.MiniDisplayWindowProperties, this);


### PR DESCRIPTION
Changed the code in the OnLoad method to set the mAppConfig.MiniDisplayWindowProperties.TopMost to the same value of the "Keep vATIS window visisble" setting in the Settings window.