### PR TITLE
Fix TTS for numbers at the end of a phrase

### DIFF
--- a/Vatsim.Vatis/Atis/AtisBuilder.cs
+++ b/Vatsim.Vatis/Atis/AtisBuilder.cs
@@ -526,7 +526,7 @@ public class AtisBuilder : IAtisBuilder
         input = Regex.Replace(input, @"\{(-?[\,0-9]+)\}", m => int.Parse(m.Groups[1].Value.Replace(",", "")).ToGroupForm());
 
         // read numbers in serial format
-        input = Regex.Replace(input, @"([+-])?([0-9]+\.?[0-9]*|\.[0-9]+)(?![^{]*\})", m => m.Value.ToSerialForm(composite.UseDecimalTerminology));
+        input = Regex.Replace(input, @"([+-])?([0-9]+\.[0-9]+|[0-9]+|\.[0-9]+)(?![^{]*\})", m => m.Value.ToSerialForm(composite.UseDecimalTerminology));
 
         input = Regex.Replace(input, @"(?<=\*)(-?[\,0-9]+)", "$1");
         input = Regex.Replace(input, @"(?<=\#)(-?[\,0-9]+)", "$1");


### PR DESCRIPTION
When numbers are placed at the end of a phrase, like `TRANSITION LEVEL 60.`, that number including the decimal `.` (which should be considered as punctuation) is passed to the function `ToSerialForm()` resulting in that `.` being stripped out. The voice ATIS would become `TRANSITION LEVEL SIX ZERO` (without the `.`) and will continue with the remaining part of the template without marking a "pause".