### PR TITLE
Make CodeRange valid for combined ATISes

### DIFF
--- a/Vatsim.Vatis/UI/ProfileConfigurationForm.Designer.cs
+++ b/Vatsim.Vatis/UI/ProfileConfigurationForm.Designer.cs
@@ -2604,7 +2604,6 @@ namespace Vatsim.Vatis.UI
             // 
             this.ddlAtisLetter.DropDownStyle = (global::System.Windows.Forms.ComboBoxStyle.DropDownList);
             this.ddlAtisLetter.FormattingEnabled = (true);
-            this.ddlAtisLetter.Items.AddRange(new global::System.Object[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" });
             this.ddlAtisLetter.Location = (new global::System.Drawing.Point(84, 58));
             this.ddlAtisLetter.Name = ("ddlAtisLetter");
             this.ddlAtisLetter.Size = (new global::System.Drawing.Size(78, 23));

--- a/Vatsim.Vatis/UI/ProfileConfigurationForm.cs
+++ b/Vatsim.Vatis/UI/ProfileConfigurationForm.cs
@@ -115,6 +115,13 @@ public partial class ProfileConfigurationForm : Form
         ddlVoices.DisplayMember = "Name";
     }
 
+    // Populates the Letter dropdown on the sandbox tab with the appropriate range of ATIS letters for the current composite
+    private void LoadAtisLetters()
+    {
+        ddlAtisLetter.Items.Clear();
+        ddlAtisLetter.Items.AddRange(Enumerable.Range(mCurrentComposite.CodeRange.Low, mCurrentComposite.CodeRange.High - mCurrentComposite.CodeRange.Low + 1).Select(i => (object)(char)i).ToArray());
+    }
+
     private TreeNode CreateTreeMenuNode(string name, object tag)
     {
         return new TreeNode
@@ -223,6 +230,7 @@ public partial class ProfileConfigurationForm : Form
 
                 LoadComposite();
                 RefreshPresetList();
+                LoadAtisLetters();
             }
         }
     }
@@ -238,18 +246,12 @@ public partial class ProfileConfigurationForm : Form
         {
             case AtisType.Combined:
                 typeCombined.Checked = true;
-                txtCodeRangeLow.Enabled = false;
-                txtCodeRangeHigh.Enabled = false;
                 break;
             case AtisType.Departure:
                 typeDeparture.Checked = true;
-                txtCodeRangeLow.Enabled = true;
-                txtCodeRangeHigh.Enabled = true;
                 break;
             case AtisType.Arrival:
                 typeArrival.Checked = true;
-                txtCodeRangeLow.Enabled = true;
-                txtCodeRangeHigh.Enabled = true;
                 break;
         }
 
@@ -812,8 +814,8 @@ public partial class ProfileConfigurationForm : Form
             return false;
         }
 
-        mCurrentComposite.CodeRange.Low = (typeDeparture.Checked || typeArrival.Checked) ? char.Parse(txtCodeRangeLow.Text) : 'A';
-        mCurrentComposite.CodeRange.High = (typeDeparture.Checked || typeArrival.Checked) ? char.Parse(txtCodeRangeHigh.Text) : 'Z';
+        mCurrentComposite.CodeRange.Low = char.Parse(txtCodeRangeLow.Text);
+        mCurrentComposite.CodeRange.High = char.Parse(txtCodeRangeHigh.Text);
 
         if (mCurrentPreset != null)
         {
@@ -1961,8 +1963,6 @@ public partial class ProfileConfigurationForm : Form
         }
 
         ddlVoices.Enabled = !radioVoiceRecorded.Checked;
-        txtCodeRangeLow.Enabled = typeDeparture.Checked || typeArrival.Checked;
-        txtCodeRangeHigh.Enabled = typeDeparture.Checked || typeArrival.Checked;
         magneticVar.Enabled = chkMagneticVar.Checked;
 
         btnApply.Enabled = true;
@@ -2111,6 +2111,8 @@ public partial class ProfileConfigurationForm : Form
 
     private void RefreshSandboxPreset()
     {
+        LoadAtisLetters();
+
         if (ddlSandboxPresets.SelectedItem != null)
         {
             mSandboxPreset = mSandboxComposite.Presets.FirstOrDefault(x => x.Id.ToString() == ddlSandboxPresets.SelectedValue.ToString());


### PR DESCRIPTION
Fixes #168 

* Remove the conditional logic that enabled/disabled the code range fields based on whether the ATIS was an arrival or departure ATIS
* Update the sandbox so the Code dropdown respects the low/high values for the ATIS letter

I was able to play around with this offline and it seems to work. I verified that if you change the code range and hit apply then the Letter dropdown on the sandbox update appropriately. The Letter dropdown also initializes with the correct range when first opened.

Setting a range for a combined ATIS:

<img width="306" alt="image" src="https://github.com/vatis-project/vatis/assets/9524118/65a05320-1efd-4589-b829-0a26b326821f">

Letter dropdown with a restricted range of letters:

<img width="85" alt="image" src="https://github.com/vatis-project/vatis/assets/9524118/ce3487a3-7635-4ab8-a224-6f1de7861b60">