### PR TITLE
Fix formating of qnh and frequency with a comma instead of a dot

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/AltimeterSettingNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/AltimeterSettingNode.cs
@@ -85,7 +85,7 @@ public class AltimeterSettingNode : BaseNodeMetarRepository<Value>
             return "";
 
         format = Regex.Replace(format, "{altimeter}", node.ActualValue.ToString(CultureInfo.InvariantCulture), RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{altimeter\|inhg}", mPressureInHg.ToString("00.00"), RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{altimeter\|inhg}", mPressureInHg.ToString("00.00", CultureInfo.GetCultureInfo("en-US")), RegexOptions.IgnoreCase);
         format = Regex.Replace(format, @"{altimeter\|hpa}", mPressureHpa.ToString(), RegexOptions.IgnoreCase);
         format = Regex.Replace(format, @"{altimeter\|text}", node.ActualValue.ToString("0000").ToSerialFormat()?.ToUpperInvariant() ?? string.Empty, RegexOptions.IgnoreCase);
 
@@ -117,7 +117,7 @@ public class AltimeterSettingNode : BaseNodeMetarRepository<Value>
             return "";
         
         format = Regex.Replace(format, "{altimeter}", ((int)node.ActualValue).ToSerialFormat(), RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{altimeter\|inhg}", mPressureInHg.ToString("00.00").ToSerialFormat(Station.AtisFormat.Altimeter.PronounceDecimal) ?? string.Empty, RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{altimeter\|inhg}", mPressureInHg.ToString("00.00", CultureInfo.GetCultureInfo("en-US")).ToSerialFormat(Station.AtisFormat.Altimeter.PronounceDecimal) ?? string.Empty, RegexOptions.IgnoreCase);
         format = Regex.Replace(format, @"{altimeter\|hpa}", mPressureHpa.ToSerialFormat(), RegexOptions.IgnoreCase);
 
         var qfeMatch = Regex.Match(format, @"\{qfe\|(\d+)\}", RegexOptions.IgnoreCase);

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -205,7 +205,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase
         
         SelectedTabIndex = -1;
         SelectedStation = station;
-        Frequency = station.Frequency > 0 ? (station.Frequency / 1000000.0).ToString("000.000") : "";
+        Frequency = station.Frequency > 0 ? (station.Frequency / 1000000.0).ToString("000.000", CultureInfo.GetCultureInfo("en-US")) : "";
         AtisType = station.AtisType;
         CodeRangeLow = station.CodeRange.Low;
         CodeRangeHigh = station.CodeRange.High;


### PR DESCRIPTION
Fixes Discord bug-reports:
- QNH missing in the ATIS
- Frequency is displayed with a comma, but can only be saved with a dot.