### PR TITLE
Prevent station-tab duplication

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -180,7 +180,10 @@ public class MainWindowViewModel : ReactiveViewModelBase
         {
             try
             {
-                mAtisStationSource.Add(mViewModelFactory.CreateAtisStationViewModel(station));
+                if (mAtisStationSource.Items.FirstOrDefault(x => x.Id == station.Id) == null)
+                {
+                    mAtisStationSource.Add(mViewModelFactory.CreateAtisStationViewModel(station));
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Only add stations for PopulateAtisStations, if they not already exist to prevent tab duplication

Fix Discord bug-reports:
- Minimize is creating a duplicate tab