### PR TITLE
Respect code range for ATIS letters

### DIFF
--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -18,7 +18,7 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
     public AtisStationView()
     {
         InitializeComponent();
-        
+
         TypeAtisLetter.KeyDown += TypeAtisLetterOnKeyDown;
         AtisLetter.DoubleTapped += AtisLetterOnDoubleTapped;
         AtisLetter.Click += AtisLetterOnClick;
@@ -29,23 +29,23 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
     {
         if (ViewModel == null)
             return;
-        
+
         if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
             return;
-        
+
         if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
         {
             ViewModel.IsAtisLetterInputMode = true;
         }
     }
-    
+
     private async void AtisLetterOnClick(object? sender, RoutedEventArgs e)
     {
         try
         {
-            if(ViewModel == null)
+            if (ViewModel == null)
                 return;
-            
+
             if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
                 return;
 
@@ -83,21 +83,29 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
     {
         if (ViewModel == null)
             return;
-        
+
         if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
             return;
 
         if (e.Key == Key.Escape)
         {
             ViewModel.IsAtisLetterInputMode = false;
-            TypeAtisLetter.Text = "A";
-            ViewModel.AtisLetter = 'A';
+            TypeAtisLetter.Text = $"{ViewModel.CodeRange.Low}";
+            ViewModel.AtisLetter = ViewModel.CodeRange.Low;
         }
         else if (e.Key == Key.Enter || e.Key == Key.Return)
         {
             ViewModel.IsAtisLetterInputMode = false;
             if (char.TryParse(TypeAtisLetter.Text?.ToUpperInvariant(), out var letter))
             {
+                if (letter > ViewModel.CodeRange.High)
+                {
+                    return;
+                }
+                if (letter < ViewModel.CodeRange.Low)
+                {
+                    return;
+                }
                 ViewModel.AtisLetter = letter;
             }
         }
@@ -141,7 +149,7 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
 
         if (!NotamFreeText.TextArea.IsFocused)
             return;
-        
+
         if (mNotamsInitialized)
         {
             ViewModel.HasUnsavedNotams = true;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -77,6 +77,11 @@ public class AtisStationViewModel : ReactiveViewModelBase
         set => this.RaiseAndSetIfChanged(ref mAtisLetter, value);
     }
 
+    public CodeRangeMeta CodeRange
+    {
+        get { return mAtisStation.CodeRange; }
+    }
+
     private bool mIsAtisLetterInputMode;
     public bool IsAtisLetterInputMode
     {
@@ -338,7 +343,7 @@ public class AtisStationViewModel : ReactiveViewModelBase
             {
                 Dispatcher.UIThread.Post(() =>
                 {
-                    AtisLetter = 'A';
+                    AtisLetter = mAtisStation.CodeRange.Low;
                     Wind = null;
                     Altimeter = null;
                     Metar = null;
@@ -994,15 +999,15 @@ public class AtisStationViewModel : ReactiveViewModelBase
         }
 
         AtisLetter++;
-        if (AtisLetter > 'Z')
-            AtisLetter = 'A';
+        if (AtisLetter > mAtisStation.CodeRange.High)
+            AtisLetter = mAtisStation.CodeRange.Low;
     }
 
     private void DecrementAtisLetter()
     {
         AtisLetter--;
-        if (AtisLetter < 'A')
-            AtisLetter = 'Z';
+        if (AtisLetter < mAtisStation.CodeRange.Low)
+            AtisLetter = mAtisStation.CodeRange.High;
     }
 
     public void Disconnect()

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -70,7 +70,7 @@ public class AtisStationViewModel : ReactiveViewModelBase
         set => this.RaiseAndSetIfChanged(ref mTabText, value);
     }
 
-    private char mAtisLetter = 'A';
+    private char mAtisLetter;
     public char AtisLetter
     {
         get => mAtisLetter;
@@ -242,6 +242,8 @@ public class AtisStationViewModel : ReactiveViewModelBase
         mCancellationToken = new CancellationTokenSource();
         mAtisStationAirport = navDataRepository.GetAirport(station.Identifier) ??
                               throw new ApplicationException($"{station.Identifier} not found in airport navdata.");
+
+        mAtisLetter = mAtisStation.CodeRange.Low;
 
         switch (station.AtisType)
         {


### PR DESCRIPTION
* Use the low code range letter when setting the initial value
* Use the code range when incrementing or decrementing the letter
* Expose the code range from the view model
* Ignore character input if a code is typed in that is outside the bounds of the specified range

Also improved the fast click and escape key experience:

* Fast single clicks without a shift key now get treated as independent clicks instead of a double click so the letter will still advance
* Esc reverts to the previously used ATIS letter instead of `A`

And fixed one bug:

* Double-clicking with the shift key down no longer advances the letter once before entering edit mode