### PR TITLE
Make all windows moveable except ProfileListDialog (own Pull Request)

### DIFF
--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -30,6 +30,8 @@ public class AppConfig : IAppConfig
 
     public WindowPosition? CompactWindowPosition { get; set; }
 
+    public WindowPosition? VoiceRecordAtisDialogWindowPosition { get; set; }
+
     public string? MicrophoneDevice { get; set; }
 
     public string? PlaybackDevice { get; set; }
@@ -62,6 +64,7 @@ public class AppConfig : IAppConfig
             AlwaysOnTop = config.AlwaysOnTop;
             MainWindowPosition = config.MainWindowPosition;
             CompactWindowPosition = config.CompactWindowPosition;
+            VoiceRecordAtisDialogWindowPosition = config.VoiceRecordAtisDialogWindowPosition;
             MicrophoneDevice = config.MicrophoneDevice;
             PlaybackDevice = config.PlaybackDevice;
         }

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -16,6 +16,7 @@ public interface IAppConfig
     string? PlaybackDevice { get; set; }
     WindowPosition? MainWindowPosition { get; set; }
     WindowPosition? CompactWindowPosition { get; set; }
+    WindowPosition? VoiceRecordAtisDialogWindowPosition { get; set; }
     void LoadConfig();
     void SaveConfig();
 }

--- a/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml
@@ -58,7 +58,7 @@
 	</Window.Styles>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent">
+			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent" PointerPressed="OnPointerPressed">
 				<TextBlock Text="New ATIS Station" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<StackPanel Orientation="Vertical" Margin="20" Spacing="15">

--- a/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -14,5 +15,13 @@ public partial class NewAtisStationDialog : ReactiveWindow<NewAtisStationDialogV
     public NewAtisStationDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/NewContractionDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/NewContractionDialog.axaml
@@ -52,7 +52,7 @@
 	</Window.Styles>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent">
+			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent" PointerPressed="OnPointerPressed">
 				<TextBlock Text="New Contraction" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<StackPanel Orientation="Vertical" Margin="20" Spacing="15">

--- a/vATIS.Desktop/Ui/Dialogs/NewContractionDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/NewContractionDialog.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
 using Slugify;
@@ -26,6 +27,14 @@ public partial class NewContractionDialog : ReactiveWindow<NewContractionDialogV
         if (e.Source is TextBox textBox)
         {
             textBox.Text = Slug.GenerateSlug(textBox.Text).ToUpperInvariant().Replace("-", "_");
+        }
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
         }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
@@ -19,7 +19,7 @@
 		Title="User Settings">
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent">
+			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent" PointerPressed="OnPointerPressed">
 				<TextBlock Text="User Settings" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<StackPanel Spacing="5" Margin="15">

--- a/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
@@ -20,5 +21,13 @@ public partial class SettingsDialog : ReactiveWindow<SettingsDialogViewModel>, I
     private void CancelButtonClicked(object sender, RoutedEventArgs e)
     {
         Close();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/SortPresetsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SortPresetsDialog.axaml
@@ -20,7 +20,7 @@
 	</Window.Resources>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 			<StackPanel Orientation="Vertical">
-				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40">
+				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40" PointerPressed="OnPointerPressed">
 					<Grid ColumnDefinitions="1*,1*">
 						<TextBlock Text="Sort Presets" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
 						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:SortPresetsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>

--- a/vATIS.Desktop/Ui/Dialogs/SortPresetsDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/SortPresetsDialog.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -14,5 +15,13 @@ public partial class SortPresetsDialog : ReactiveWindow<SortPresetsDialogViewMod
     public SortPresetsDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/StaticAirportConditionsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/StaticAirportConditionsDialog.axaml
@@ -60,7 +60,7 @@
 				<Border Background="#000000" Opacity="0.80"/>
 			</Grid>
 			<StackPanel Orientation="Vertical">
-				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40">
+				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40" PointerPressed="OnPointerPressed">
 					<Grid ColumnDefinitions="1*,1*">
 						<TextBlock Text="Airport Conditions" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
 						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:StaticAirportConditionsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>

--- a/vATIS.Desktop/Ui/Dialogs/StaticAirportConditionsDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/StaticAirportConditionsDialog.axaml.cs
@@ -1,3 +1,5 @@
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -16,5 +18,13 @@ public partial class StaticAirportConditionsDialog : ReactiveWindow<StaticAirpor
     public StaticAirportConditionsDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Border or TextBlock && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/StaticDefinitionEditorDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/StaticDefinitionEditorDialog.axaml
@@ -54,7 +54,7 @@
 	</Window.Styles>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border CornerRadius="5,5,0,0" Background="#282828" Height="40">
+			<Border CornerRadius="5,5,0,0" Background="#282828" Height="40" PointerPressed="OnPointerPressed">
 				<Grid ColumnDefinitions="1*,1*">
 					<TextBlock Text="{Binding Title, DataType=vm:StaticDefinitionEditorDialogViewModel, FallbackValue='Definition Editor'}" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
 					<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CancelButtonCommand, DataType=vm:StaticDefinitionEditorDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>

--- a/vATIS.Desktop/Ui/Dialogs/StaticDefinitionEditorDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/StaticDefinitionEditorDialog.axaml.cs
@@ -1,3 +1,5 @@
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -14,5 +16,13 @@ public partial class StaticDefinitionEditorDialog : ReactiveWindow<StaticDefinit
     public StaticDefinitionEditorDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Border or TextBlock && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/StaticNotamsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/StaticNotamsDialog.axaml
@@ -60,7 +60,7 @@
 				<Border Background="#000000" Opacity="0.80"/>
 			</Grid>
 			<StackPanel Orientation="Vertical">
-				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40">
+				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40" PointerPressed="OnPointerPressed">
 					<Grid ColumnDefinitions="1*,1*">
 						<TextBlock Text="NOTAMs" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
 						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:StaticNotamsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>

--- a/vATIS.Desktop/Ui/Dialogs/StaticNotamsDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/StaticNotamsDialog.axaml.cs
@@ -1,3 +1,5 @@
+using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -15,5 +17,13 @@ public partial class StaticNotamsDialog : ReactiveWindow<StaticNotamsDialogViewM
     public StaticNotamsDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Border or TextBlock && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/TransitionLevelDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/TransitionLevelDialog.axaml
@@ -52,7 +52,7 @@
 	</Window.Styles>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent">
+			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent" PointerPressed="OnPointerPressed">
 				<TextBlock Text="Transition Level" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<StackPanel Orientation="Vertical" Margin="20" Spacing="15">

--- a/vATIS.Desktop/Ui/Dialogs/TransitionLevelDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/TransitionLevelDialog.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -14,5 +15,13 @@ public partial class TransitionLevelDialog : ReactiveWindow<TransitionLevelDialo
     public TransitionLevelDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/UserInputDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/UserInputDialog.axaml
@@ -18,7 +18,7 @@
 		Background="Transparent">
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
 		<StackPanel>
-			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent">
+			<Border BorderBrush="#646464" BorderThickness="0,0,0,1" Background="Transparent" PointerPressed="OnPointerPressed">
 				<TextBlock Text="{Binding Title, DataType=vm:UserInputDialogViewModel, FallbackValue=Title}" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<StackPanel Spacing="5" Margin="15" HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/vATIS.Desktop/Ui/Dialogs/UserInputDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/UserInputDialog.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -14,5 +15,13 @@ public partial class UserInputDialog : ReactiveWindow<UserInputDialogViewModel>,
     public UserInputDialog()
     {
         InitializeComponent();
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/VoiceRecordAtisDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/VoiceRecordAtisDialog.axaml
@@ -63,7 +63,7 @@
 			<Grid x:Name="Overlay" Grid.ColumnSpan="2" Grid.RowSpan="2" ZIndex="100" IsVisible="{Binding ShowOverlay, DataType=vm:VoiceRecordAtisDialogViewModel, FallbackValue=False}">
 				<Border Background="#000000" Opacity="0.80"/>
 			</Grid>
-			<Border Background="#1e1e1e" Grid.Row="0" CornerRadius="5,5,0,0">
+			<Border Background="#1e1e1e" Grid.Row="0" CornerRadius="5,5,0,0"  PointerPressed="OnPointerPressed">
 				<TextBlock Text="Record ATIS" Padding="5" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" />
 			</Border>
 			<Grid Grid.Row="1" ColumnDefinitions="1*,25,1*" Margin="30">

--- a/vATIS.Desktop/Ui/Dialogs/VoiceRecordAtisDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/VoiceRecordAtisDialog.axaml.cs
@@ -1,4 +1,7 @@
 using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
 using Vatsim.Vatis.Ui.ViewModels;
 
@@ -21,5 +24,32 @@ public partial class VoiceRecordAtisDialog : ReactiveWindow<VoiceRecordAtisDialo
     {
         base.OnOpened(e);
         ViewModel!.DialogOwner = this;
+    }
+
+    private void OnPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+
+        PositionChanged += OnPositionChanged;
+        if (DataContext is VoiceRecordAtisDialogViewModel model)
+        {
+            model.RestorePosition(this);
+        }
+    }
+
+    private void OnPositionChanged(object? sender, PixelPointEventArgs e)
+    {
+        if (DataContext is VoiceRecordAtisDialogViewModel model)
+        {
+            model.UpdatePosition(this);
+        }
     }
 }

--- a/vATIS.Desktop/Ui/Services/WindowLocationService.cs
+++ b/vATIS.Desktop/Ui/Services/WindowLocationService.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Platform;
 using System.Linq;
 using Vatsim.Vatis.Config;
+using Vatsim.Vatis.Ui.Dialogs;
 
 namespace Vatsim.Vatis.Ui.Services;
 public class WindowLocationService : IWindowLocationService
@@ -67,6 +68,28 @@ public class WindowLocationService : IWindowLocationService
             mLeft = mAppConfig.CompactWindowPosition.X;
             mTop = mAppConfig.CompactWindowPosition.Y;
         }
+        else if (window.GetType() == typeof(VoiceRecordAtisDialog))
+        {
+            if (mAppConfig.VoiceRecordAtisDialogWindowPosition == null)
+            {
+                // No settings found to restore, so center the window on the primary screen.
+                var primaryScreen = window.Screens.Primary;
+                if (primaryScreen == null) return;
+                var screenWorkingArea = primaryScreen.WorkingArea;
+
+                var centeredLeft = (int)(screenWorkingArea.X + ((screenWorkingArea.Width - window.Width) / 2));
+                var centeredTop = (int)(screenWorkingArea.Y + ((screenWorkingArea.Height - window.Height) / 2));
+
+                mLeft = centeredLeft;
+                mTop = centeredTop;
+
+                mAppConfig.VoiceRecordAtisDialogWindowPosition = new WindowPosition(centeredLeft, centeredTop);
+                mAppConfig.SaveConfig();
+                return;
+            }
+            mLeft = mAppConfig.VoiceRecordAtisDialogWindowPosition.X;
+            mTop = mAppConfig.VoiceRecordAtisDialogWindowPosition.Y;
+        }
 
         if (mLeft is null || mTop is null)
             return;
@@ -110,6 +133,11 @@ public class WindowLocationService : IWindowLocationService
         else if (window.GetType() == typeof(Windows.CompactWindow))
         {
             mAppConfig.CompactWindowPosition = savedPosition;
+            mAppConfig.SaveConfig();
+        }
+        else if (window.GetType() == typeof(VoiceRecordAtisDialog))
+        {
+            mAppConfig.VoiceRecordAtisDialogWindowPosition = savedPosition;
             mAppConfig.SaveConfig();
         }
     }

--- a/vATIS.Desktop/Ui/ViewModels/VoiceRecordAtisDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/VoiceRecordAtisDialogViewModel.cs
@@ -13,12 +13,14 @@ using Avalonia.Threading;
 using ReactiveUI;
 using Vatsim.Vatis.Config;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
+using Vatsim.Vatis.Ui.Services;
 using Vatsim.Vatis.Voice.Audio;
 
 namespace Vatsim.Vatis.Ui.ViewModels;
 
 public class VoiceRecordAtisDialogViewModel : ReactiveObject
 {
+    private readonly IWindowLocationService mWindowLocationService;
     private readonly Stopwatch mRecordingStopwatch;
     private readonly System.Timers.Timer mElapsedTimeUpdateTimer;
     private readonly System.Timers.Timer mMaxRecordingDurationTimer;
@@ -140,8 +142,11 @@ public class VoiceRecordAtisDialogViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> ListenCommand { get; private set; }
     public Window? DialogOwner { get; set; }
 
-    public VoiceRecordAtisDialogViewModel(IAppConfig appConfig)
+    public VoiceRecordAtisDialogViewModel(
+        IAppConfig appConfig,
+        IWindowLocationService windowLocationService)
     {
+        mWindowLocationService = windowLocationService;
         mRecordingStopwatch = new Stopwatch();
         mElapsedTimeUpdateTimer = new System.Timers.Timer();
         mElapsedTimeUpdateTimer.Interval = 50;
@@ -357,5 +362,21 @@ public class VoiceRecordAtisDialogViewModel : ReactiveObject
         }
 
         return result;
+    }
+
+    public void UpdatePosition(Window? window)
+    {
+        if (window == null)
+            return;
+
+        mWindowLocationService.Update(window);
+    }
+
+    public void RestorePosition(Window? window)
+    {
+        if (window == null)
+            return;
+
+        mWindowLocationService.Restore(window);
     }
 }

--- a/vATIS.Desktop/Ui/Windows/MainWindow.axaml.cs
+++ b/vATIS.Desktop/Ui/Windows/MainWindow.axaml.cs
@@ -38,7 +38,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
     private void OnPointerPressed(object sender, PointerPressedEventArgs e)
     {
-        if (e.Source is Border && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        if (e.Source is Border or TextBlock && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
             BeginMoveDrag(e);
         }


### PR DESCRIPTION
Implement Discord feature-request:
- Allow Voice ATIS Recording menu to be moved

Moveable ProfileListDialog: https://github.com/vatis-project/vatis/pull/4

**Moveablity Matrix:**
  | Moveable | Save Position
-- | -- | --
AtisConfigurationWindow | 1 | 0
CompactWindow | 1 | 1
MainWindow | 1 | 1
NewAtisStationDialog | 1 | 0
NewContractionDialog | 1 | 0
ProfileListDialog | 1 | 1
SettingsDialog | 1 | 0
SortPresetsDialog | 1 | 0
StartupWindow | 0 | 0
StaticAirportConditionsDialog | 1 | 0
StaticDefinitionEditorDialog | 1 | 0
StaticNotamsDialog | 1 | 0
TransitionLevelDialog | 1 | 0
UserInputDialog | 1 | 0
VoiceRecordAtisDialog | 1 | 1
