### PR TITLE
Add an open button to the profile list dialog

### DIFF
--- a/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
+++ b/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
@@ -1,17 +1,9 @@
 <Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:converters="using:Vatsim.Vatis.Ui.Converters"
-		xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
-		mc:Ignorable="d"
-        x:Class="Vatsim.Vatis.Ui.Profiles.ProfileListDialog"
-        Title="vATIS Profiles" Height="375" Width="300"
-		WindowStartupLocation="CenterScreen" SystemDecorations="None"
-		Icon="/Assets/MainIcon.ico"
-		CanResize="False" 
-        Background="Transparent" 
-        TransparencyLevelHint="Transparent">
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:converters="using:Vatsim.Vatis.Ui.Converters"
+	xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels" mc:Ignorable="d" x:Class="Vatsim.Vatis.Ui.Profiles.ProfileListDialog" Title="vATIS Profiles" Height="375" Width="300" WindowStartupLocation="CenterScreen" SystemDecorations="None" Icon="/Assets/MainIcon.ico" CanResize="False" Background="Transparent" TransparencyLevelHint="Transparent">
 	<Window.Resources>
 		<converters:BoolToBrushColorConverter x:Key="BoolToBrushColorConverter" TrueColor="Black" FalseColor="#646464"/>
 	</Window.Resources>
@@ -67,6 +59,8 @@
 					<StackPanel Grid.Column="1" Orientation="Vertical">
 						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding ShowNewProfileDialogCommand, DataType=vm:ProfileListViewModel}">New</Button>
 						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding ImportProfileCommand, DataType=vm:ProfileListViewModel}">Import</Button>
+						<Border Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="1" Margin="0,5" />
+						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding StartClientSessionCommand, DataType=vm:ProfileListViewModel}" CommandParameter="{Binding #ProfileList.SelectedItem}">Open</Button>
 						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding RenameProfileCommand, DataType=vm:ProfileListViewModel}" CommandParameter="{Binding #ProfileList.SelectedItem}">Rename</Button>
 						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding ExportProfileCommand, DataType=vm:ProfileListViewModel}">Export</Button>
 						<Button Theme="{StaticResource Dark}" HorizontalAlignment="Stretch" Margin="0,3" Command="{Binding DeleteProfileCommand, DataType=vm:ProfileListViewModel}" CommandParameter="{Binding #ProfileList.SelectedItem}">Delete</Button>

--- a/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
@@ -42,10 +42,10 @@ public class ProfileListViewModel : ReactiveViewModelBase
         get => mShowOverlay;
         set => this.RaiseAndSetIfChanged(ref mShowOverlay, value);
     }
-    
+
     public string ClientVersion { get; }
     #endregion
-    
+
     public ReactiveCommand<Unit, Unit> InitializeCommand { get; }
     public ReactiveCommand<Unit, Unit> ShowNewProfileDialogCommand { get; }
     public ReactiveCommand<ProfileViewModel, Unit> RenameProfileCommand { get; }
@@ -54,7 +54,7 @@ public class ProfileListViewModel : ReactiveViewModelBase
     public ReactiveCommand<Unit, Unit> ExportProfileCommand { get; }
     public ReactiveCommand<ProfileViewModel, Unit> StartClientSessionCommand { get; }
     public ReactiveCommand<Unit, Unit> ExitCommand { get; }
-    
+
     private readonly ISessionManager mSessionManager;
     private readonly IWindowFactory mWindowFactory;
     private readonly IProfileRepository mProfileRepository;
@@ -81,7 +81,7 @@ public class ProfileListViewModel : ReactiveViewModelBase
         ImportProfileCommand = ReactiveCommand.CreateFromTask(HandleImportProfile);
         ExportProfileCommand = ReactiveCommand.CreateFromTask(HandleExportProfile, canExecute);
         DeleteProfileCommand = ReactiveCommand.CreateFromTask<ProfileViewModel>(HandleDeleteProfile, canExecute);
-        StartClientSessionCommand = ReactiveCommand.Create<ProfileViewModel>(HandleStartSession);
+        StartClientSessionCommand = ReactiveCommand.Create<ProfileViewModel>(HandleStartSession, canExecute);
         ExitCommand = ReactiveCommand.Create(HandleExit);
 
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
@@ -186,7 +186,7 @@ public class ProfileListViewModel : ReactiveViewModelBase
                         context.SetError("Profile name is required.");
                         return;
                     }
-                    
+
                     var profile = new Profile { Name = context.UserValue.Trim() };
                     mProfileList.Add(new ProfileViewModel(profile));
                     mProfileRepository.Save(profile);
@@ -212,7 +212,7 @@ public class ProfileListViewModel : ReactiveViewModelBase
             foreach (var file in files)
             {
                 var newProfile = await mProfileRepository.Import(file);
-                mProfileList.Add(new ProfileViewModel(newProfile));   
+                mProfileList.Add(new ProfileViewModel(newProfile));
             }
         }
         catch (Exception ex)
@@ -237,7 +237,7 @@ public class ProfileListViewModel : ReactiveViewModelBase
 
         if (file == null)
             return;
-        
+
         mProfileRepository.Export(SelectedProfile.Profile, file.Path.LocalPath);
         await MessageBox.ShowDialog((Window)mDialogOwner, "Profile successfully exported.", "Success",
             MessageBoxButton.Ok, MessageBoxIcon.Information);


### PR DESCRIPTION
Right now, the only way to open a profile is to double-click on it. Once you've done it once you know that's the way. For new users it's not obvious. There's space in the dialog for an open button and it goes well with export, rename, delete.

* Add the open button, re-using the existing command from double-click
* Add a separator to divide the "applies to selected profile" actions from the rest

## No profile selected

![image](https://github.com/user-attachments/assets/307f6640-b504-4bff-be38-97f02177dea4)

## Profile selected

![image](https://github.com/user-attachments/assets/f925c519-7a22-4a30-b877-2c0558c8363a)
