### PR TITLE
VATIS-89: Spacing after NOTAMS and show NOTAMS without prefix in use

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -374,8 +374,8 @@ public class AtisBuilder : IAtisBuilder
         var notamsVoice = "";
         if (station.UseNotamPrefix && !string.IsNullOrEmpty(notams))
         {
-            notamsText += $"NOTAMS... {notams}";
-            notamsVoice += $"{(station.IsFaaAtis ? "Notices to air missions" : "Notices to airmen")}: {notams}";
+            notamsText += $"NOTAMS... {notams} ";
+            notamsVoice += $"{(station.IsFaaAtis ? "Notices to air missions" : "Notices to airmen")}: {notams} ";
         }
         
         // translate contraction variables

--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -372,10 +372,16 @@ public class AtisBuilder : IAtisBuilder
 
         var notamsText = "";
         var notamsVoice = "";
-        if (station.UseNotamPrefix && !string.IsNullOrEmpty(notams))
+        if (station.UseNotamPrefix)
         {
-            notamsText += $"NOTAMS... {notams} ";
-            notamsVoice += $"{(station.IsFaaAtis ? "Notices to air missions" : "Notices to airmen")}: {notams} ";
+            notamsText += "NOTAMS... ";
+            notamsVoice += $"{(station.IsFaaAtis ? "Notices to air missions" : "Notices to airmen")}: ";
+        }
+
+        if (!string.IsNullOrEmpty(notams))
+        {
+            notamsText += $"{notams} ";
+            notamsVoice += $"{notams} ";
         }
         
         // translate contraction variables


### PR DESCRIPTION
Fix Discord Issues:
- [VATIS-89] NOTAMs removes space before closing statement
- NOTAMs not outputting