### PR TITLE
VATIS-88: Add dot to the end of the closing statement default template

### DIFF
--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/ClosingStatement.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/ClosingStatement.cs
@@ -5,7 +5,7 @@ public class ClosingStatement : BaseFormat
     {
         Template = new()
         {
-            Text = "...ADVS YOU HAVE INFO {letter}",
+            Text = "...ADVS YOU HAVE INFO {letter}.",
             Voice = "ADVISE ON INITIAL CONTACT, YOU HAVE INFORMATION {letter|word}"
         };
     }


### PR DESCRIPTION
Fix Discord issues:  
\- \[VATIS-88\] Closing statement default text should end with a period