### PR TITLE
Only add free text before notams if free text is not empty & Add dot after the last notam/the free text

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -361,9 +361,13 @@ public class AtisBuilder : IAtisBuilder
             }
             else
             {
-                notams += string.Join(".", preset.Notams,
-                    string.Join(".", station.NotamDefinitions.Where(x => x.Enabled).Select(t => t.Text)));
+                if (!string.IsNullOrEmpty(preset.Notams))
+                {
+                    notams += preset.Notams + ".";
+                }
+                notams += string.Join(".", station.NotamDefinitions.Where(x => x.Enabled).Select(t => t.Text));
             }
+            notams += ".";
         }
         
         // strip extraneous punctuation


### PR DESCRIPTION
Fix Discord bug-reports:
- "NOTICES TO AIR MISSIONS" mispronounced when user-fillable NOTAMs section is blank