### PR TITLE
Fix ATIS letter missing in FSD ATIS query response

### DIFF
--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -245,7 +245,7 @@ public class NetworkConnection : INetworkConnection
                 if (_atisStation?.AtisLetter != null)
                 {
                     _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
-                        ["A", _atisStation.AtisLetter]));
+                        ["A", _atisStation.AtisLetter.ToString()]));
                 }
 
                 break;

--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -242,11 +242,8 @@ public class NetworkConnection : INetworkConnection
                 num++;
                 _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
                     ["E", num.ToString()]));
-                if (_atisStation?.AtisLetter != null)
-                {
-                    _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
-                        ["A", _atisStation.AtisLetter.ToString()]));
-                }
+                _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
+                    ["A", _atisStation?.AtisLetter.ToString() ?? string.Empty]));
 
                 break;
             case ClientQueryType.Inf:

--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -249,7 +249,7 @@ public class NetworkConnection : INetworkConnection
                 if (mAtisStation?.AtisLetter != null)
                 {
                     mFsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.PDU.From, ClientQueryType.ATIS,
-                        ["A", mAtisStation.AtisLetter]));
+                        ["A", mAtisStation.AtisLetter.ToString()]));
                 }
 
                 break;

--- a/vATIS.Desktop/Profiles/Models/AtisStation.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisStation.cs
@@ -51,7 +51,7 @@ public class AtisStation : ReactiveObject
 
     [JsonIgnore] public bool IsFaaAtis => (Identifier.StartsWith('K') || Identifier.StartsWith('P'));
     [JsonIgnore] public string? TextAtis { get; set; }
-    [JsonIgnore] public string? AtisLetter { get; set; }
+    [JsonIgnore] public char AtisLetter { get; set; }
 
     // Legacy
     [Obsolete("Use 'Frequency' instead")]

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -543,6 +543,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         await Task.Run(async () =>
                         {
                             mAtisStation.TextAtis = atisBuilder.TextAtis;
+                            mAtisStation.AtisLetter = AtisLetter;
                             
                             await PublishAtisToHub();
                             mNetworkConnection.SendSubscriberNotification(AtisLetter);
@@ -813,6 +814,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         mCancellationToken.Token);
 
                     mAtisStation.TextAtis = atisBuilder.TextAtis?.ToUpperInvariant();
+                    mAtisStation.AtisLetter = AtisLetter;
                     
                     await PublishAtisToHub();
                     mNetworkConnection?.SendSubscriberNotification(AtisLetter);
@@ -934,6 +936,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     mCancellationToken.Token);
                 
                 mAtisStation.TextAtis = atisBuilder.TextAtis?.ToUpperInvariant();
+                mAtisStation.AtisLetter = AtisLetter;
 
                 await PublishAtisToHub();
                 await PublishAtisToWebsocket();
@@ -1015,6 +1018,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         mDecodedMetar, mCancellationToken.Token);
 
                     mAtisStation.TextAtis = atisBuilder.TextAtis?.ToUpperInvariant();
+                    mAtisStation.AtisLetter = AtisLetter;
 
                     await PublishAtisToHub();
                     mNetworkConnection?.SendSubscriberNotification(AtisLetter);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- None

- **Bug Fixes**
	- Updated ATIS letter handling to ensure proper string conversion.
	- Improved public IP address initialization with default empty string.

- **Refactor**
	- Changed `AtisLetter` property from nullable string to non-nullable character type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->