### PR TITLE
Add temperature/dewpoint range symbol variable for text ATIS

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
@@ -30,9 +30,14 @@ public class DewpointNode : BaseNode<Value>
         if (format == null)
             return "";
 
-        return Regex.Replace(format, "{dewpoint}",
-            string.Concat(value.ActualValue < 0 ? "M" : "", Math.Abs((int)value.ActualValue).ToString("00")),
-            RegexOptions.IgnoreCase);
+        if (Station == null)
+            return "";
+
+        format = Regex.Replace(format, "{dewpoint}", string.Concat(value.ActualValue < 0 && Station.IsFaaAtis ? "M" : "",
+            Math.Abs(value.ActualValue).ToString("00")), RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{prefix_symbol}", value.ActualValue < 0 ? "-" : "+", RegexOptions.IgnoreCase);
+
+        return format;
     }
 
     public override string ParseVoiceVariables(Value node, string? format)

--- a/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
@@ -30,9 +30,14 @@ public class TemperatureNode : BaseNode<Value>
         if (format == null)
             return "";
 
-        return Regex.Replace(format, "{temp}",
-            string.Concat(value.ActualValue < 0 ? "M" : "", Math.Abs(value.ActualValue).ToString("00")),
-            RegexOptions.IgnoreCase);
+        if (Station == null)
+            return "";
+
+        format = Regex.Replace(format, "{temp}", string.Concat(value.ActualValue < 0 && Station.IsFaaAtis ? "M" : "",
+            Math.Abs(value.ActualValue).ToString("00")), RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{prefix_symbol}", value.ActualValue < 0 ? "-" : "+", RegexOptions.IgnoreCase);
+
+        return format;
     }
 
     public override string ParseVoiceVariables(Value node, string? format)

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -607,6 +607,13 @@
 									CommandParameter="{Binding $self.Content}">
 									{temp}
 								</Button>
+								<Button
+									Theme="{StaticResource DarkVariable}"
+									ToolTip.Tip="The prefix symbol used to indicate a positive (+) or negative (-) value. Only applies to text ATIS."
+									Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
+									CommandParameter="{Binding $self.Content}">
+									{prefix__symbol}
+								</Button>
 							</StackPanel>
 						</StackPanel>
 					</controls:GroupBox>
@@ -636,6 +643,13 @@
 									Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
 									CommandParameter="{Binding $self.Content}">
 									{dewpoint}
+								</Button>
+								<Button
+									Theme="{StaticResource DarkVariable}"
+									ToolTip.Tip="The prefix symbol used to indicate a positive (+) or negative (-) value. Only applies to text ATIS."
+									Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
+									CommandParameter="{Binding $self.Content}">
+									{prefix__symbol}
 								</Button>
 							</StackPanel>
 						</StackPanel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added prefix symbol buttons for temperature and dewpoint formatting.
  - Enhanced temperature and dewpoint text parsing with more precise formatting options.

- **Improvements**
  - Improved handling of temperature and dewpoint values for different station types.
  - Added support for displaying positive and negative value prefixes.

These updates provide more flexible and accurate ATIS text generation, giving users greater control over temperature and dewpoint representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->