### PR TITLE
Add formatting parameters to temperature and dewpoint template variables

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
@@ -29,10 +29,35 @@ public class DewpointNode : BaseNode<Value>
     {
         if (format == null)
             return "";
+    
+        // Parse the input format.
+        // Matches patterns like {dewpoint}, {dewpoint:00}, {dewpoint:00P}, or {dewpoint:P}.
+        // - "P" (optional) suppresses the "M" prefix for negative values.
+        // - Numeric digits (optional) specify the minimum number of digits to display.
+        var match = Regex.Match(format, @"\{dewpoint(?::(?<format>[0-9]*P?))?\}");
+        if (!match.Success)
+        {
+            throw new ArgumentException("Invalid format string");
+        }
 
-        return Regex.Replace(format, "{dewpoint}",
-            string.Concat(value.ActualValue < 0 ? "M" : "", Math.Abs((int)value.ActualValue).ToString("00")),
-            RegexOptions.IgnoreCase);
+        // Extract the format part (e.g., "00" or "00P")
+        string formatting = match.Groups["format"].Value;
+    
+        // Check if the "P" parameter is present, which suppresses the "M" prefix
+        bool suppressM = formatting.Contains('P');
+    
+        // Remove "P" from the format to get the numeric part (if any)
+        string digitFormat = formatting.Replace("P", "").Trim();
+    
+        // Default to "00" if no digit format is provided
+        if (string.IsNullOrEmpty(digitFormat)) digitFormat = "00";
+    
+        // Format the dewpoint
+        if (value.ActualValue < 0 && !suppressM) // Only prefix "M" if negative and not suppressed
+        {
+            return $"M{Math.Abs(value.ActualValue).ToString(digitFormat)}";
+        }
+        return Math.Abs(value.ActualValue).ToString(digitFormat);
     }
 
     public override string ParseVoiceVariables(Value node, string? format)

--- a/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/DewpointNode.cs
@@ -37,7 +37,7 @@ public class DewpointNode : BaseNode<Value>
         var match = Regex.Match(format, @"\{dewpoint(?::(?<format>[0-9]*P?))?\}");
         if (!match.Success)
         {
-            throw new ArgumentException("Invalid format string");
+            throw new ArgumentException("Invalid dewpoint format string: " + format);
         }
 
         // Extract the format part (e.g., "00" or "00P")

--- a/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
@@ -29,35 +29,43 @@ public class TemperatureNode : BaseNode<Value>
     {
         if (format == null)
             return "";
-    
-        // Parse the input format.
-        // Matches patterns like {temp}, {temp:00}, {temp:00P}, or {temp:P}.
-        // - "P" (optional) suppresses the "M" prefix for negative values.
-        // - Numeric digits (optional) specify the minimum number of digits to display.
-        var match = Regex.Match(format, @"\{temp(?::(?<format>[0]*P?))?\}");
+
+        // Parse the input format using regex to match patterns like {temp}, {temp:##}, {temp:##M}, or {temp:M}
+        var match = Regex.Match(format, @"\{temp(?::(?<format>#*M?))?\}");
         if (!match.Success)
         {
             throw new ArgumentException("Invalid temperature format string: " + format);
         }
 
-        // Extract the format part (e.g., "00" or "00P")
+        // Extract the format part (e.g., "##" or "##M")
         string formatting = match.Groups["format"].Value;
-    
-        // Check if the "P" parameter is present, which suppresses the "M" prefix
-        bool suppressM = formatting.Contains('P');
-    
-        // Remove "P" from the format to get the numeric part (if any)
-        string digitFormat = formatting.Replace("P", "").Trim();
-    
-        // Default to "00" if no digit format is provided
+
+        // Check if the "M" character is present, indicating whether to suppress the "M" prefix
+        bool suppressM = formatting.Contains('M');
+
+        // Remove "M" from the format (if present) to get the numeric part
+        string digitFormat = formatting.Replace("M", "").Trim();
+
+        // Default to "00" if no digit format is provided (i.e., no '#' symbols)
         if (string.IsNullOrEmpty(digitFormat)) digitFormat = "00";
-    
-        // Format the temperature
+
+        // Count the number of '#' symbols to determine the format (e.g., 2 '#' symbols -> "00")
+        int digitCount = digitFormat.Length;
+
+        // Format the temperature value
+        string formattedValue;
+        string formatString = new string('0', digitCount); // Create a format string like "00", "000", etc.
+
         if (value.ActualValue < 0 && !suppressM) // Only prefix "M" if negative and not suppressed
         {
-            return $"M{Math.Abs(value.ActualValue).ToString(digitFormat)}";
+            formattedValue = $"M{Math.Abs(value.ActualValue).ToString(formatString)}";
         }
-        return Math.Abs(value.ActualValue).ToString(digitFormat);
+        else
+        {
+            formattedValue = Math.Abs(value.ActualValue).ToString(formatString);
+        }
+
+        return formattedValue;
     }
 
     public override string ParseVoiceVariables(Value node, string? format)

--- a/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
@@ -29,10 +29,35 @@ public class TemperatureNode : BaseNode<Value>
     {
         if (format == null)
             return "";
+    
+        // Parse the input format.
+        // Matches patterns like {temp}, {temp:00}, {temp:00P}, or {temp:P}.
+        // - "P" (optional) suppresses the "M" prefix for negative values.
+        // - Numeric digits (optional) specify the minimum number of digits to display.
+        var match = Regex.Match(format, @"\{temp(?::(?<format>[0]*P?))?\}");
+        if (!match.Success)
+        {
+            throw new ArgumentException("Invalid temperature format string: " + format);
+        }
 
-        return Regex.Replace(format, "{temp}",
-            string.Concat(value.ActualValue < 0 ? "M" : "", Math.Abs(value.ActualValue).ToString("00")),
-            RegexOptions.IgnoreCase);
+        // Extract the format part (e.g., "00" or "00P")
+        string formatting = match.Groups["format"].Value;
+    
+        // Check if the "P" parameter is present, which suppresses the "M" prefix
+        bool suppressM = formatting.Contains('P');
+    
+        // Remove "P" from the format to get the numeric part (if any)
+        string digitFormat = formatting.Replace("P", "").Trim();
+    
+        // Default to "00" if no digit format is provided
+        if (string.IsNullOrEmpty(digitFormat)) digitFormat = "00";
+    
+        // Format the temperature
+        if (value.ActualValue < 0 && !suppressM) // Only prefix "M" if negative and not suppressed
+        {
+            return $"M{Math.Abs(value.ActualValue).ToString(digitFormat)}";
+        }
+        return Math.Abs(value.ActualValue).ToString(digitFormat);
     }
 
     public override string ParseVoiceVariables(Value node, string? format)

--- a/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TemperatureNode.cs
@@ -68,7 +68,7 @@ public class TemperatureNode : BaseNode<Value>
             formattedValue = Math.Abs(value.ActualValue).ToString(formatString);
         }
 
-        // Replace the {dewpoint} variable in the format string with the formatted value
+        // Replace the temperature placeholder in the format string with the formatted value
         format = format.Replace(match.Value, formattedValue);
 
         return format;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced formatting for dewpoint and temperature values.
	- Introduced regex-based parsing for more flexible format strings.
	- Improved error handling for invalid format inputs.

- **Bug Fixes**
	- Refined logic for displaying negative temperature and dewpoint values.
	- Enhanced handling of the `{prefix_symbol}` placeholder for temperature formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->