### PR TITLE
Refactor AtisBuilder: separate voice and text build methods

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -45,15 +45,15 @@ public class AtisBuilder : IAtisBuilder
         ArgumentNullException.ThrowIfNull(station);
         ArgumentNullException.ThrowIfNull(preset);
         ArgumentNullException.ThrowIfNull(decodedMetar);
-        
-        var airportData = mNavDataRepository?.GetAirport(station.Identifier) ??
+
+        var airportData = _navDataRepository?.GetAirport(station.Identifier) ??
                           throw new AtisBuilderException($"{station.Identifier} not found in airport database.");
 
         var variables = await ParseNodesFromMetar(station, preset, decodedMetar, airportData, currentAtisLetter);
 
         var (spokenText, audioBytes) = await CreateVoiceAtis(station, preset, currentAtisLetter, variables,
             cancellationToken, sandboxRequest);
-        
+
         return new AtisBuilderVoiceAtisResponse(spokenText, audioBytes);
     }
 
@@ -68,9 +68,9 @@ public class AtisBuilder : IAtisBuilder
 
         var airportData = _navDataRepository?.GetAirport(station.Identifier) ??
                           throw new AtisBuilderException($"{station.Identifier} not found in airport database.");
-        
+
         var variables = await ParseNodesFromMetar(station, preset, decodedMetar, airportData, currentAtisLetter);
-        
+
         return await CreateTextAtis(station, preset, currentAtisLetter, variables);
     }
 

--- a/vATIS.Desktop/Atis/AtisBuilderResponse.cs
+++ b/vATIS.Desktop/Atis/AtisBuilderResponse.cs
@@ -1,3 +1,0 @@
-namespace Vatsim.Vatis.Atis;
-
-public record AtisBuilderResponse(string? TextAtis, string? SpokenText, byte[]? AudioBytes);

--- a/vATIS.Desktop/Atis/AtisBuilderVoiceAtisResponse.cs
+++ b/vATIS.Desktop/Atis/AtisBuilderVoiceAtisResponse.cs
@@ -1,0 +1,3 @@
+namespace Vatsim.Vatis.Atis;
+
+public record AtisBuilderVoiceAtisResponse(string? SpokenText, byte[]? AudioBytes);

--- a/vATIS.Desktop/Atis/IAtisBuilder.cs
+++ b/vATIS.Desktop/Atis/IAtisBuilder.cs
@@ -7,7 +7,9 @@ namespace Vatsim.Vatis.Atis;
 
 public interface IAtisBuilder
 {
-    Task<AtisBuilderResponse> BuildAtis(AtisStation station, AtisPreset preset, char currentAtisLetter,
+    Task<AtisBuilderVoiceAtisResponse> BuildVoiceAtis(AtisStation station, AtisPreset preset, char currentAtisLetter,
         DecodedMetar decodedMetar, CancellationToken cancellationToken, bool sandboxRequest = false);
+    Task<string?> BuildTextAtis(AtisStation station, AtisPreset preset, char currentAtisLetter,
+        DecodedMetar decodedMetar, CancellationToken cancellationToken);
     Task UpdateIds(AtisStation station, AtisPreset preset, char currentAtisLetter, CancellationToken cancellationToken);
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
@@ -271,11 +271,11 @@ public class SandboxViewModel : ReactiveViewModelBase
 
             if (SandboxMetar != null)
             {
-                var decodedMetar = mMetarDecoder.ParseNotStrict(SandboxMetar);
-                var textAtis = await mAtisBuilder.BuildTextAtis(SelectedStation, SelectedPreset, randomLetter,
-                    decodedMetar, mCancellationToken.Token);
-                AtisBuilderVoiceAtisResponse = await mAtisBuilder.BuildVoiceAtis(SelectedStation, SelectedPreset, randomLetter,
-                    decodedMetar, mCancellationToken.Token, true);
+                var decodedMetar = _metarDecoder.ParseNotStrict(SandboxMetar);
+                var textAtis = await _atisBuilder.BuildTextAtis(SelectedStation, SelectedPreset, randomLetter,
+                    decodedMetar, _cancellationToken.Token);
+                AtisBuilderVoiceAtisResponse = await _atisBuilder.BuildVoiceAtis(SelectedStation, SelectedPreset, randomLetter,
+                    decodedMetar, _cancellationToken.Token, true);
                 SandboxTextAtis = textAtis?.ToUpperInvariant();
                 SandboxSpokenTextAtis = AtisBuilderVoiceAtisResponse.SpokenText?.ToUpperInvariant();
             }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -532,8 +532,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 var window = _windowFactory.CreateVoiceRecordAtisDialog();
                 if (window.DataContext is VoiceRecordAtisDialogViewModel vm)
                 {
-                    var textAtis = await mAtisBuilder.BuildTextAtis(mAtisStation, SelectedAtisPreset, AtisLetter, mDecodedMetar,
-                        mCancellationToken.Token);
+                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
+                        _cancellationToken.Token);
 
                     vm.AtisScript = textAtis;
                     window.Topmost = lifetime.MainWindow.Topmost;
@@ -542,8 +542,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     {
                         await Task.Run(async () =>
                         {
-                            mAtisStation.TextAtis = textAtis;
-                            
+                            _atisStation.TextAtis = textAtis;
+
                             await PublishAtisToHub();
                             _networkConnection.SendSubscriberNotification(AtisLetter);
                             await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter,
@@ -809,26 +809,26 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     _cancellationToken.Dispose();
                     _cancellationToken = new CancellationTokenSource();
 
-                    var textAtis = await mAtisBuilder.BuildTextAtis(mAtisStation, SelectedAtisPreset, AtisLetter, e.Metar,
-                        mCancellationToken.Token);
+                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, e.Metar,
+                        _cancellationToken.Token);
 
-                    mAtisStation.TextAtis = textAtis?.ToUpperInvariant();
-                    
+                    _atisStation.TextAtis = textAtis?.ToUpperInvariant();
+
                     await PublishAtisToWebsocket();
                     await PublishAtisToHub();
                     _networkConnection?.SendSubscriberNotification(AtisLetter);
                     await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
 
-                    var voiceAtis = await mAtisBuilder.BuildVoiceAtis(mAtisStation, SelectedAtisPreset, AtisLetter,
-                        e.Metar, mCancellationToken.Token);
-                    
-                    if (voiceAtis.AudioBytes != null && mNetworkConnection != null)
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                        e.Metar, _cancellationToken.Token);
+
+                    if (voiceAtis.AudioBytes != null && _networkConnection != null)
                     {
                         await Task.Run(async () =>
                         {
-                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, mAtisStation.Frequency,
-                                mAtisStationAirport.Latitude, mAtisStationAirport.Longitude, 100);
-                            await mVoiceServerConnection?.AddOrUpdateBot(mNetworkConnection.Callsign, dto, mCancellationToken.Token)!;
+                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                                _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
+                            await _voiceServerConnection?.AddOrUpdateBot(_networkConnection.Callsign, dto, _cancellationToken.Token)!;
                         }).ContinueWith(t =>
                         {
                             if (t.IsFaulted)
@@ -931,10 +931,10 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 if (_decodedMetar == null)
                     return;
 
-                var textAtis = await mAtisBuilder.BuildTextAtis(mAtisStation, SelectedAtisPreset, AtisLetter, mDecodedMetar,
-                    mCancellationToken.Token);
-                
-                mAtisStation.TextAtis = textAtis?.ToUpperInvariant();
+                var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
+                    _cancellationToken.Token);
+
+                _atisStation.TextAtis = textAtis?.ToUpperInvariant();
 
                 await PublishAtisToHub();
                 await PublishAtisToWebsocket();
@@ -947,18 +947,18 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     _cancellationToken.Dispose();
                     _cancellationToken = new CancellationTokenSource();
 
-                    var voiceAtis = await mAtisBuilder.BuildVoiceAtis(mAtisStation, SelectedAtisPreset, AtisLetter,
-                        mDecodedMetar, mCancellationToken.Token);
-                    
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                        _decodedMetar, _cancellationToken.Token);
+
                     if (voiceAtis.AudioBytes != null)
                     {
                         await Task.Run(async () =>
                         {
-                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, mAtisStation.Frequency,
-                                mAtisStationAirport.Latitude, mAtisStationAirport.Longitude, 100);
-                            await mVoiceServerConnection?.AddOrUpdateBot(mNetworkConnection.Callsign, dto,
-                                mCancellationToken.Token)!;
-                        }, mCancellationToken.Token);
+                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                                _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
+                            await _voiceServerConnection?.AddOrUpdateBot(_networkConnection.Callsign, dto,
+                                _cancellationToken.Token)!;
+                        }, _cancellationToken.Token);
                     }
                 }
             }
@@ -1022,25 +1022,25 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 try
                 {
-                    var textAtis = await mAtisBuilder.BuildTextAtis(mAtisStation, SelectedAtisPreset, atisLetter,
-                        mDecodedMetar, mCancellationToken.Token);
+                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, atisLetter,
+                        _decodedMetar, _cancellationToken.Token);
 
-                    mAtisStation.TextAtis = textAtis?.ToUpperInvariant();
+                    _atisStation.TextAtis = textAtis?.ToUpperInvariant();
 
                     await PublishAtisToHub();
                     _networkConnection?.SendSubscriberNotification(AtisLetter);
                     await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter,
                         _cancellationToken.Token);
 
-                    var voiceAtis = await mAtisBuilder.BuildVoiceAtis(mAtisStation, SelectedAtisPreset, AtisLetter,
-                        mDecodedMetar, mCancellationToken.Token);
-                    
-                    if (voiceAtis.AudioBytes != null && mNetworkConnection != null)
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                        _decodedMetar, _cancellationToken.Token);
+
+                    if (voiceAtis.AudioBytes != null && _networkConnection != null)
                     {
-                        var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, mAtisStation.Frequency,
-                            mAtisStationAirport.Latitude, mAtisStationAirport.Longitude, 100);
-                        mVoiceServerConnection?.AddOrUpdateBot(mNetworkConnection.Callsign, dto,
-                            mCancellationToken.Token);
+                        var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                            _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
+                        _voiceServerConnection?.AddOrUpdateBot(_networkConnection.Callsign, dto,
+                            _cancellationToken.Token);
                     }
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Separated ATIS generation into distinct text and voice methods.
  - Introduced new `AtisBuilderVoiceAtisResponse` for voice ATIS data.

- **Refactor**
  - Renamed `BuildAtis` method to `BuildVoiceAtis`.
  - Created new `BuildTextAtis` method for text-based ATIS generation.
  - Updated interfaces and view models to support new ATIS generation approach.

- **Breaking Changes**
  - Removed `AtisBuilderResponse` record.
  - Changed method signatures in ATIS-related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->