### PR TITLE
Expose ceiling and prevailing visibility to websocket clients

### DIFF
--- a/vATIS.Desktop/Ui/Services/WebsocketMessages/AtisMessage.cs
+++ b/vATIS.Desktop/Ui/Services/WebsocketMessages/AtisMessage.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Vatsim.Vatis.Networking;
 using Vatsim.Vatis.Profiles.Models;
+using Vatsim.Vatis.Weather.Decoder.Entity;
 using static Vatsim.Vatis.Weather.Decoder.Entity.Value;
 
 namespace Vatsim.Vatis.Ui.Services.WebsocketMessages;
@@ -85,14 +86,9 @@ public class AtisMessage
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Altimeter { get; set; }
 
-        [JsonPropertyName("pressureUnit")]
-        [JsonConverter(typeof(JsonStringEnumConverter<Unit>))]
+        [JsonPropertyName("pressure")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public Unit? PressureUnit { get; set; }
-
-        [JsonPropertyName("pressureValue")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public double? PressureValue { get; set; }
+        public Value? Pressure { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the ATIS message is new.
@@ -100,5 +96,20 @@ public class AtisMessage
         [JsonPropertyName("isNewAtis")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IsNewAtis { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the current ceiling at the station. If there is no ceiling
+        /// then no value is sent.
+        /// </summary>
+        [JsonPropertyName("ceiling")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Value? Ceiling { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the current visibility at the station.
+        /// </summary>
+        [JsonPropertyName("prevailingVisibility")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Value? PrevailingVisibility { get; set; }
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -543,12 +543,12 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         await Task.Run(async () =>
                         {
                             mAtisStation.TextAtis = atisBuilder.TextAtis;
-                            
+
                             await PublishAtisToHub();
                             mNetworkConnection.SendSubscriberNotification(AtisLetter);
                             await mAtisBuilder.UpdateIds(mAtisStation, SelectedAtisPreset, AtisLetter,
                                 mCancellationToken.Token);
-                            
+
                             var dto = AtisBotUtils.AddBotRequest(vm.AudioBuffer, mAtisStation.Frequency,
                                 mAtisStationAirport.Latitude, mAtisStationAirport.Longitude, 100);
                             await mVoiceServerConnection?.AddOrUpdateBot(mNetworkConnection.Callsign, dto,
@@ -813,7 +813,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         mCancellationToken.Token);
 
                     mAtisStation.TextAtis = atisBuilder.TextAtis?.ToUpperInvariant();
-                    
+
                     await PublishAtisToHub();
                     mNetworkConnection?.SendSubscriberNotification(AtisLetter);
                     await mAtisBuilder.UpdateIds(mAtisStation, SelectedAtisPreset, AtisLetter, mCancellationToken.Token);
@@ -882,8 +882,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             TextAtis = mAtisStation.TextAtis,
             IsNewAtis = IsNewAtis,
             NetworkConnectionStatus = NetworkConnectionStatus,
-            PressureUnit = mDecodedMetar?.Pressure?.Value?.ActualUnit,
-            PressureValue = mDecodedMetar?.Pressure?.Value?.ActualValue,
+            Pressure = mDecodedMetar?.Pressure?.Value,
+            Ceiling = mDecodedMetar?.Ceiling?.BaseHeight,
+            PrevailingVisibility = mDecodedMetar?.Visibility?.PrevailingVisibility
         });
     }
 
@@ -932,7 +933,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                 var atisBuilder = await mAtisBuilder.BuildAtis(mAtisStation, SelectedAtisPreset, AtisLetter, mDecodedMetar,
                     mCancellationToken.Token);
-                
+
                 mAtisStation.TextAtis = atisBuilder.TextAtis?.ToUpperInvariant();
 
                 await PublishAtisToHub();
@@ -1120,7 +1121,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        
+
         mWebsocketService.GetAtisReceived -= OnGetAtisReceived;
         mWebsocketService.AcknowledgeAtisUpdateReceived -= OnAcknowledgeAtisUpdateReceived;
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -882,9 +882,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             TextAtis = mAtisStation.TextAtis,
             IsNewAtis = IsNewAtis,
             NetworkConnectionStatus = NetworkConnectionStatus,
-            Pressure = mDecodedMetar?.Pressure?.Value,
-            Ceiling = mDecodedMetar?.Ceiling?.BaseHeight,
-            PrevailingVisibility = mDecodedMetar?.Visibility?.PrevailingVisibility
+            Pressure = mDecodedMetar?.Pressure?.Value ?? null,
+            Ceiling = mDecodedMetar?.Ceiling?.BaseHeight ?? null,
+            PrevailingVisibility = mDecodedMetar?.Visibility?.PrevailingVisibility ?? null
         });
     }
 
@@ -1120,8 +1120,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     public void Dispose()
     {
-        GC.SuppressFinalize(this);
-
         mWebsocketService.GetAtisReceived -= OnGetAtisReceived;
         mWebsocketService.AcknowledgeAtisUpdateReceived -= OnAcknowledgeAtisUpdateReceived;
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -891,9 +891,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             TextAtis = _atisStation.TextAtis,
             IsNewAtis = IsNewAtis,
             NetworkConnectionStatus = NetworkConnectionStatus,
-            Pressure = _DecodedMetar?.Pressure?.Value ?? null,
-            Ceiling = _DecodedMetar?.Ceiling?.BaseHeight ?? null,
-            PrevailingVisibility = _DecodedMetar?.Visibility?.PrevailingVisibility ?? null
+            Pressure = _decodedMetar?.Pressure?.Value ?? null,
+            Ceiling = _decodedMetar?.Ceiling?.BaseHeight ?? null,
+            PrevailingVisibility = _decodedMetar?.Visibility?.PrevailingVisibility ?? null
         });
     }
 

--- a/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
+++ b/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
@@ -22,9 +22,10 @@ public sealed class CloudChunkDecoder : MetarChunkDecoder
     private static CloudLayer? CalculateCeiling(List<CloudLayer> layers)
     {
         var ceiling = layers
-            .Where(n => n.BaseHeight?.ActualValue > 0 &&
-                        n.Amount is CloudLayer.CloudAmount.Overcast or CloudLayer.CloudAmount.Broken)
-            .Select(n => n)
+            .Where(n => n.BaseHeight != null &&
+                    n.BaseHeight.ActualValue > 0 &&
+                    (n.Amount == CloudLayer.CloudAmount.Overcast ||
+                     n.Amount == CloudLayer.CloudAmount.Broken))
             .OrderBy(n => n.BaseHeight?.ActualValue)
             .FirstOrDefault();
 

--- a/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
+++ b/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Avalonia.OpenGL.Egl;
 using Vatsim.Vatis.Weather.Decoder.ChunkDecoder.Abstract;
 using Vatsim.Vatis.Weather.Decoder.Entity;
 using Vatsim.Vatis.Weather.Decoder.Exception;

--- a/vATIS.Desktop/Weather/Decoder/Entity/DecodedMetar.cs
+++ b/vATIS.Desktop/Weather/Decoder/Entity/DecodedMetar.cs
@@ -109,6 +109,11 @@ public class DecodedMetar
     public List<CloudLayer> Clouds { get; set; } = [];
 
     /// <summary>
+    /// The lowest cloud layer that is broken or overcast
+    /// </summary>
+    public CloudLayer? Ceiling { get; set; }
+
+    /// <summary>
     /// Temperature information
     /// </summary>
     public Value? AirTemperature { get; set; }
@@ -137,7 +142,7 @@ public class DecodedMetar
     /// Windshear runway information (which runways, or "all")
     /// </summary>
     public List<string>? WindshearRunways { get; set; }
-    
+
     /// <summary>
     /// TREND forecast
     /// </summary>


### PR DESCRIPTION
This introduces a breaking change to the websocket ATIS message. `pressureValue` and `pressureUnit` are replaced with a single `pressure` property that is a `Value` object. This aligns it with the new `Ceiling` and `PrevailingVisibility` properties.

Is `PrevailingVisibility` the right one to expose? 🤔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced METAR data processing with new cloud ceiling and visibility tracking.
	- Added support for more detailed meteorological information in ATIS messages.

- **Improvements**
	- Streamlined pressure and cloud layer data representation.
	- Improved handling of meteorological data parsing and publishing.

- **Technical Updates**
	- Updated data models to consolidate pressure and cloud layer information.
	- Refined websocket message structure for more comprehensive weather reporting.
	- Introduced calculation of cloud ceiling based on parsed METAR data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->