### PR TITLE
Tweak vscode config to reduce irritation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,65 +1,80 @@
 {
-  "compounds": [
-    {
-      "name": "Launch dev server & debug vATIS.Desktop",
-      "configurations": [
-        "Launch dev server",
-        "Launch vATIS.Desktop - Dev server"
-      ],
-      "stopAll": true
-    }
-  ],
-  "configurations": [
-    {
-      "name": "Launch dev server",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "Build DevServer",
-      "program": "${workspaceFolder}/DevServer/bin/Debug/net8.0/DevServer.exe",
-      "args": [],
-      "cwd": "${workspaceFolder}",
-      "stopAtEntry": false,
-      "console": "internalConsole",
-      "launchSettingsProfile": "http",
-      "launchSettingsFilePath": "${workspaceFolder}/DevServer/Properties/launchSettings.json",
-      "presentation": {
-        "hidden": true,
-        "group": "",
-        "order": 1
-      },
-      "logging": {
-        "moduleLoad": false
-      }
-    },
-    {
-      "name": "Launch vATIS.Desktop - Production",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "Build vATIS.Desktop",
-      "program": "${workspaceFolder}/vATIS.Desktop/bin/Debug/net8.0/vATIS.exe",
-      "args": [],
-      "cwd": "${workspaceFolder}",
-      "stopAtEntry": false,
-      "console": "internalConsole",
-      "logging": {
-        "moduleLoad": false
-      }
-    },
-    {
-      "name": "Launch vATIS.Desktop - Dev server",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "Build vATIS.Desktop",
-      "program": "${workspaceFolder}/vATIS.Desktop/bin/Debug/net8.0/vATIS.exe",
-      "args": [],
-      "cwd": "${workspaceFolder}",
-      "stopAtEntry": false,
-      "console": "internalConsole",
-      "launchSettingsProfile": "vATIS.Desktop - Dev server",
-      "launchSettingsFilePath": "${workspaceFolder}/vATIS.Desktop/Properties/launchSettings.json",
-      "logging": {
-        "moduleLoad": false
-      }
-    }
-  ]
+    "compounds": [
+        {
+            "name": "Launch dev server & debug vATIS.Desktop",
+            "configurations": [
+                "Launch dev server",
+                "Launch dev server UI - Edge",
+                "Launch vATIS.Desktop - Dev server"
+            ],
+            "stopAll": true
+        }
+    ],
+    "configurations": [
+        {
+            "name": "Launch dev server UI - Edge",
+            "request": "launch",
+            "type": "msedge",
+            "url": "http://127.0.0.1:5500/",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "Launch dev server UI - Chrome",
+            "request": "launch",
+            "type": "chrome",
+            "url": "http://127.0.0.1:5500/",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "Launch dev server",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build DevServer",
+            "program": "${workspaceFolder}/DevServer/bin/Debug/net8.0/DevServer.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "launchSettingsProfile": "http",
+            "launchSettingsFilePath": "${workspaceFolder}/DevServer/Properties/launchSettings.json",
+            "presentation": {
+                "hidden": true,
+                "group": "",
+                "order": 1
+            },
+            "logging": {
+                "moduleLoad": false
+            }
+        },
+        {
+            "name": "Launch vATIS.Desktop - Production",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build vATIS.Desktop",
+            "program": "${workspaceFolder}/vATIS.Desktop/bin/Debug/net8.0/vATIS.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "logging": {
+                "moduleLoad": false
+            }
+        },
+        {
+            "name": "Launch vATIS.Desktop - Dev server",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build vATIS.Desktop",
+            "program": "${workspaceFolder}/vATIS.Desktop/bin/Debug/net8.0/vATIS.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "launchSettingsProfile": "vATIS.Desktop - Dev server",
+            "launchSettingsFilePath": "${workspaceFolder}/vATIS.Desktop/Properties/launchSettings.json",
+            "logging": {
+                "moduleLoad": false
+            }
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
-  "files.exclude": {
-    "**/.run": true,
-    "**/.vs": true,
-    "DevServer/bin": true,
-    "DevServer/obj": true
-  },
-  "explorer.fileNesting.enabled": true,
-  "explorer.fileNesting.patterns": {
-    "README.md": "CONTRIBUTING.md,LICENSE"
-  },
-  "dotnet.defaultSolution": "vATIS.sln",
-  "cmake.sourceDirectory": "${workspaceFolder}/NativeAudio"
+    "files.exclude": {
+        "**/.run": true,
+        "**/.vs": true,
+        "DevServer/bin": true,
+        "DevServer/obj": true
+    },
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+        "README.md": "CONTRIBUTING.md,LICENSE"
+    },
+    "dotnet.defaultSolution": "vATIS.sln",
+    "cmake.sourceDirectory": "${workspaceFolder}/NativeAudio",
+    "cmake.revealLog": "error"
 }


### PR DESCRIPTION
Makes two tweaks to the vscode config files to reduce my annoyance factor while developing:

* Changes cmake so it doesn't constantly bring the output window forward when it is loading stuff. It will now only pop forward when errors occur
* Add launch tasks for Edge and Chrome that bring up the dev UI, and default to including the Edge launch in the launch config that runs the dev server and vATIS. Now pressing F5 does everything you need to start testing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added browser-specific launch configurations for development server UI in Edge and Chrome
	- Introduced CMake error log reveal setting

- **Chores**
	- Updated VS Code debug and settings configurations to improve development workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->