### PR TITLE
Decode METAR for observed stations

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -37,6 +37,7 @@ using Vatsim.Vatis.Ui.Services.WebsocketMessages;
 using Vatsim.Vatis.Voice.Audio;
 using Vatsim.Vatis.Voice.Network;
 using Vatsim.Vatis.Voice.Utils;
+using Vatsim.Vatis.Weather.Decoder;
 using Vatsim.Vatis.Weather.Decoder.Entity;
 using WatsonWebsocket;
 
@@ -233,6 +234,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 sync.Dto.AtisType == station.AtisType &&
                 NetworkConnectionStatus != NetworkConnectionStatus.Connected)
             {
+                if (!string.IsNullOrEmpty(sync.Dto.Metar))
+                {
+                    _decodedMetar = new MetarDecoder().Parse(sync.Dto.Metar);
+                }
+
                 Dispatcher.UIThread.Post(() =>
                 {
                     AtisLetter = sync.Dto.AtisLetter;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -59,6 +59,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private readonly IWebsocketService _websocketService;
     private readonly ISessionManager _sessionManager;
     private readonly Airport _atisStationAirport;
+    private readonly MetarDecoder _metarDecoder = new();
     private CancellationTokenSource _cancellationToken;
     private AtisPreset? _previousAtisPreset;
     private DecodedMetar? _decodedMetar;
@@ -236,7 +237,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 if (!string.IsNullOrEmpty(sync.Dto.Metar))
                 {
-                    _decodedMetar = new MetarDecoder().Parse(sync.Dto.Metar);
+                    _decodedMetar = _metarDecoder.Parse(sync.Dto.Metar);
                 }
 
                 Dispatcher.UIThread.Post(() =>


### PR DESCRIPTION
This fixes missing visibility and pressure values in web socket message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved METAR data parsing to prevent errors when handling empty or null METAR strings
- **Refactor**
	- Enhanced error handling in ATIS station view model
<!-- end of auto-generated comment: release notes by coderabbit.ai -->