### PR TITLE
Don't allow fetching of D-ATIS letter for observed stations

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -360,6 +360,9 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
         if (string.IsNullOrEmpty(selectedStation.Identifier))
             return;
 
+        if (selectedStation.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
+            return;
+
         var requestDto = new DigitalAtisRequestDto
         {
             Id = selectedStation.Identifier, AtisType = selectedStation.AtisType


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved digital ATIS letter request logic to prevent unnecessary requests when a station is in observer mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->