### PR TITLE
MaxDropDownHeight must be multiple of 4

### DIFF
--- a/vATIS.Desktop/Ui/Styles/DarkComboBox.axaml
+++ b/vATIS.Desktop/Ui/Styles/DarkComboBox.axaml
@@ -13,7 +13,7 @@
 	<Style Selector="ComboBox.Dark">
 
 		<Setter Property="HorizontalAlignment" Value="Stretch"/>
-		<Setter Property="MaxDropDownHeight" Value="150" />
+		<Setter Property="MaxDropDownHeight" Value="140" />
 		<Setter Property="Foreground" Value="#C0C0C0" />
 		<Setter Property="Background" Value="#1E1E1E" />
 		<Setter Property="BorderBrush" Value="#646464" />


### PR DESCRIPTION
Ensures `MaxDropDownHeight` is a multiple of 4 to avoid invalid dropdown popup panel widths on scaled displays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the maximum dropdown height for dark-themed combo boxes, reducing the maximum display area slightly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->