### PR TITLE
Add option to automatically fetch real-world ATIS letter

### DIFF
--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -59,6 +59,9 @@ public class AppConfig : IAppConfig
     public string? PlaybackDevice { get; set; }
 
     /// <inheritdoc />
+    public bool AutoFetchAtisLetter { get; set; }
+
+    /// <inheritdoc />
     [JsonIgnore]
     public string PasswordDecrypted
     {
@@ -97,6 +100,7 @@ public class AppConfig : IAppConfig
             VoiceRecordAtisDialogWindowPosition = config.VoiceRecordAtisDialogWindowPosition;
             MicrophoneDevice = config.MicrophoneDevice;
             PlaybackDevice = config.PlaybackDevice;
+            AutoFetchAtisLetter = config.AutoFetchAtisLetter;
         }
 
         SaveConfig();

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -88,6 +88,11 @@ public interface IAppConfig
     WindowPosition? VoiceRecordAtisDialogWindowPosition { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to auto-fetch the ATIS letter.
+    /// </summary>
+    bool AutoFetchAtisLetter { get; set; }
+
+    /// <summary>
     /// Loads the configuration settings for the application.
     /// </summary>
     void LoadConfig();

--- a/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
@@ -45,6 +45,7 @@
 				</StackPanel>
 				<StackPanel>
 					<CheckBox Theme="{StaticResource CheckBox}" Content="Suppress ATIS update notification sound" IsChecked="{Binding SuppressNotificationSound, DataType=vm:SettingsDialogViewModel}" />
+					<CheckBox Theme="{StaticResource CheckBox}" Content="Automatically fetch ATIS letter" ToolTip.Tip="Fetch the real-world ATIS letter for supported stations automatically after connecting to the network." IsChecked="{Binding AutoFetchAtisLetter, DataType=vm:SettingsDialogViewModel}" />
 				</StackPanel>
 				<Grid ColumnDefinitions="1*,5,1*">
 					<Button Theme="{StaticResource Dark}" Grid.Column="0" HorizontalAlignment="Stretch" Content="Save" Command="{Binding SaveSettingsCommand, DataType=vm:SettingsDialogViewModel}" CommandParameter="{Binding ElementName=Window}" IsDefault="True" />

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -972,21 +972,28 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                // Fetch the real-world ATIS letter if the user has enabled this option.
-                if (_appConfig.AutoFetchAtisLetter)
+                try
                 {
-                    if (!string.IsNullOrEmpty(Identifier))
+                    // Fetch the real-world ATIS letter if the user has enabled this option.
+                    if (_appConfig.AutoFetchAtisLetter)
                     {
-                        var requestDto = new DigitalAtisRequestDto { Id = Identifier, AtisType = AtisType };
-                        var atisLetter = await _atisHubConnection.GetDigitalAtisLetter(requestDto);
-                        if (atisLetter != null)
+                        if (!string.IsNullOrEmpty(Identifier))
                         {
-                            SetAtisLetterCommand.Execute(atisLetter.Value).Subscribe();
+                            var requestDto = new DigitalAtisRequestDto { Id = Identifier, AtisType = AtisType };
+                            var atisLetter = await _atisHubConnection.GetDigitalAtisLetter(requestDto);
+                            if (atisLetter != null)
+                            {
+                                SetAtisLetterCommand.Execute(atisLetter.Value).Subscribe();
+                            }
                         }
                     }
-                }
 
-                NetworkConnectionStatus = NetworkConnectionStatus.Connected;
+                    NetworkConnectionStatus = NetworkConnectionStatus.Connected;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Unhandled exception in OnNetworkConnected async lambda.");
+                }
             });
         }
         catch (Exception ex)

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -966,11 +966,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         NativeAudio.EmitSound(SoundType.Error);
     }
 
-    private void OnNetworkConnected(object? sender, EventArgs e)
+    private async void OnNetworkConnected(object? sender, EventArgs e)
     {
-        Dispatcher.UIThread.Post(async void () =>
+        try
         {
-            try
+            await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 // Fetch the real-world ATIS letter if the user has enabled this option.
                 if (_appConfig.AutoFetchAtisLetter)
@@ -987,12 +987,12 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 }
 
                 NetworkConnectionStatus = NetworkConnectionStatus.Connected;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "OnNetworkConnected failed.");
-            }
-        });
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unhandled exception in OnNetworkConnected.");
+        }
     }
 
     private void OnNetworkDisconnected(object? sender, EventArgs e)

--- a/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
@@ -26,6 +26,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     private string? _selectedNetworkRating;
     private ObservableCollection<ComboBoxItemMeta>? _networkRatings;
     private bool _suppressNotificationSound;
+    private bool _autoFetchAtisLetter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SettingsDialogViewModel"/> class.
@@ -40,6 +41,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         Password = _appConfig.PasswordDecrypted;
         SuppressNotificationSound = _appConfig.SuppressNotificationSound;
         SelectedNetworkRating = _appConfig.NetworkRating.ToString();
+        AutoFetchAtisLetter = _appConfig.AutoFetchAtisLetter;
 
         NetworkRatings =
         [
@@ -119,6 +121,15 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref _suppressNotificationSound, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically fetch real-world ATIS letter.
+    /// </summary>
+    public bool AutoFetchAtisLetter
+    {
+        get => _autoFetchAtisLetter;
+        set => this.RaiseAndSetIfChanged(ref _autoFetchAtisLetter, value);
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -132,6 +143,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         _appConfig.UserId = UserId?.Trim() ?? "";
         _appConfig.PasswordDecrypted = Password?.Trim() ?? "";
         _appConfig.SuppressNotificationSound = SuppressNotificationSound;
+        _appConfig.AutoFetchAtisLetter = AutoFetchAtisLetter;
 
         if (Enum.TryParse(SelectedNetworkRating, out NetworkRating selectedNetworkRating))
         {

--- a/vATIS.Desktop/Ui/Windows/MainWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/MainWindow.axaml
@@ -17,9 +17,6 @@
         Title="vATIS"
 		Icon="/Assets/MainIcon.ico"
 		Topmost="{Binding IsTopMost, DataType=vm:TopMostViewModel, Source={x:Static vm:TopMostViewModel.Instance}}">
-	<Window.KeyBindings>
-		<KeyBinding Gesture="Ctrl+D" Command="{Binding GetDigitalAtisLetterCommand, DataType=vm:MainWindowViewModel}"/>
-	</Window.KeyBindings>
 	<Border CornerRadius="5"
 			BorderBrush="Black"
 			BorderThickness="1"


### PR DESCRIPTION
- Add option to automatically fetch real-world ATIS letter after connecting ATIS to network.
- Remove CTRL+D gesture to fetch ATIS letter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added option to automatically fetch ATIS letter after network connection.
  - New settings toggle in application configuration to control auto-fetch behavior.

- **Bug Fixes**
  - Enhanced error handling for network connection updates.

- **Changes**
  - Removed manual D-ATIS letter retrieval command and keyboard shortcut.
  - Updated network connection handling to support optional automatic ATIS letter fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->