### PR TITLE
Don't parse METAR in strict mode

### DIFF
--- a/vATIS.Desktop/Networking/AtisHub/MockAtisHubConnection.cs
+++ b/vATIS.Desktop/Networking/AtisHub/MockAtisHubConnection.cs
@@ -28,6 +28,7 @@ public class MockAtisHubConnection : IAtisHubConnection
 {
     private readonly IDownloader _downloader;
     private readonly IAppConfigurationProvider _appConfigurationProvider;
+    private readonly MetarDecoder _metarDecoder;
     private HubConnection? _hubConnection;
     private ConnectionState _hubConnectionState;
 
@@ -40,6 +41,7 @@ public class MockAtisHubConnection : IAtisHubConnection
     {
         _downloader = downloader;
         _appConfigurationProvider = appConfigurationProvider;
+        _metarDecoder = new MetarDecoder();
     }
 
     /// <inheritdoc />
@@ -75,8 +77,7 @@ public class MockAtisHubConnection : IAtisHubConnection
             {
                 try
                 {
-                    var decoder = new MetarDecoder();
-                    var metar = decoder.ParseStrict(message);
+                    var metar = _metarDecoder.ParseNotStrict(message);
                     MessageBus.Current.SendMessage(new MetarReceived(metar));
                 }
                 catch (Exception ex)

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -237,7 +237,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 if (!string.IsNullOrEmpty(sync.Dto.Metar))
                 {
-                    _decodedMetar = _metarDecoder.Parse(sync.Dto.Metar);
+                    _decodedMetar = _metarDecoder.ParseNotStrict(sync.Dto.Metar);
                 }
 
                 Dispatcher.UIThread.Post(() =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated METAR parsing logic to use a more flexible, non-strict decoding method
- **Bug Fixes**
  - Improved handling of METAR message parsing to accommodate potential variations in message format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->