### PR TITLE
Automatically remove @ symbol after selecting an auto-completion item

### DIFF
--- a/vATIS.Desktop/Ui/Behaviors/TextEditorCompletionBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/TextEditorCompletionBehavior.cs
@@ -52,6 +52,7 @@ public class TextEditorCompletionBehavior : Behavior<TextEditor>
         _textEditor.TextArea.KeyUp += OnTextEditorKeyUp;
         _textEditor.TextArea.TextEntered += TextAreaOnTextEntered;
         _textEditor.Options.CompletionAcceptAction = CompletionAcceptAction.DoubleTapped;
+        _textEditor.Options.AllowScrollBelowDocument = false;
     }
 
     private void OnTextEditorKeyUp(object? sender, KeyEventArgs e)

--- a/vATIS.Desktop/Ui/Behaviors/TextEditorCompletionBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/TextEditorCompletionBehavior.cs
@@ -27,6 +27,7 @@ public class TextEditorCompletionBehavior : Behavior<TextEditor>
 
     private CompletionWindow? _completionWindow;
     private TextEditor? _textEditor;
+    private int _triggerPosition = -1;
 
     /// <summary>
     /// Gets or sets the list of completion data entries used for populating the code completion suggestions in the associated <see cref="TextEditor"/> control.
@@ -48,43 +49,61 @@ public class TextEditorCompletionBehavior : Behavior<TextEditor>
         }
 
         _textEditor = editor;
+        _textEditor.TextArea.KeyUp += OnTextEditorKeyUp;
         _textEditor.TextArea.TextEntered += TextAreaOnTextEntered;
         _textEditor.Options.CompletionAcceptAction = CompletionAcceptAction.DoubleTapped;
     }
 
-    private void TextAreaOnTextEntered(object? sender, TextInputEventArgs e)
+    private void OnTextEditorKeyUp(object? sender, KeyEventArgs e)
     {
-        if (string.IsNullOrEmpty(e.Text))
-        {
-            return;
-        }
-
-        if (_completionWindow == null && !string.IsNullOrWhiteSpace(e.Text) && !char.IsNumber(e.Text[0]))
-        {
-            if (e.Text == "@")
-            {
-                if (CompletionData.Count > 0)
-                {
-                    ShowCompletion();
-                }
-            }
-        }
-        else if (_completionWindow != null && !char.IsLetterOrDigit(e.Text[0]))
+        // If enter or tab is pressed when the completion window is open,
+        // request insertion of the selection contraction.
+        if ((e.Key == Key.Enter || e.Key == Key.Tab) && _completionWindow is not null)
         {
             _completionWindow.CompletionList.RequestInsertion(e);
         }
     }
 
-    private void ShowCompletion()
+    private void TextAreaOnTextEntered(object? sender, TextInputEventArgs e)
     {
-        if (_completionWindow != null)
-        {
+        if (string.IsNullOrWhiteSpace(e.Text))
             return;
+
+        if (e.Text == "@")
+        {
+            // Record the position of the '@' symbol
+            _triggerPosition = _textEditor?.TextArea.Caret.Offset - 1 ?? -1;
+            TriggerCompletionWindow();
+        }
+    }
+
+    private void TriggerCompletionWindow()
+    {
+        // Don't show completion window if there is no completion data.
+        if (CompletionData.Count == 0)
+            return;
+
+        _completionWindow = null;
+        _completionWindow ??= new CompletionWindow(_textEditor?.TextArea);
+        _completionWindow.CompletionList.CompletionData.AddRange(CompletionData);
+        _completionWindow.CompletionList.InsertionRequested += (_, _) => RemoveAtSymbol();
+        _completionWindow.Closed += (_, _) => _completionWindow = null;
+        _completionWindow.Show();
+    }
+
+    private void RemoveAtSymbol()
+    {
+        if (_textEditor == null || _triggerPosition < 0)
+            return;
+
+        // Remove the '@' symbol if it's still present at the recorded position
+        if (_triggerPosition < _textEditor.Document.TextLength &&
+            _textEditor.Document.GetCharAt(_triggerPosition) == '@')
+        {
+            _textEditor.Document.Remove(_triggerPosition, 1);
         }
 
-        _completionWindow = new CompletionWindow(_textEditor?.TextArea);
-        _completionWindow.CompletionList.CompletionData.AddRange(CompletionData);
-        _completionWindow.Show();
-        _completionWindow.Closed += (_, _) => _completionWindow = null;
+        // Reset the trigger position
+        _triggerPosition = -1;
     }
 }

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -76,7 +76,6 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
         if (ViewModel == null)
             return;
 
-        NotamFreeText.Options.AllowScrollBelowDocument = false;
         NotamFreeText.TextArea.Caret.PositionChanged += (_, _) =>
         {
             if (ViewModel?.ReadOnlyNotams == null)
@@ -94,7 +93,6 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
             }
         };
 
-        AirportConditions.Options.AllowScrollBelowDocument = false;
         AirportConditions.TextArea.Caret.PositionChanged += (_, _) =>
         {
             if (ViewModel?.ReadOnlyAirportConditions == null)


### PR DESCRIPTION
The auto-completion window is triggered by the @ symbol, which is automatically removed when an auto-completion item is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced text editor completion behavior with improved '@' symbol handling.
  - Added advanced key event management for completion window interactions.
  - Dynamic updating of contraction data based on selected station changes.

- **Bug Fixes**
  - Improved completion window trigger logic to prevent unnecessary displays.
  - Added mechanism to remove '@' symbol during completion insertion.
  - Simplified scrolling behavior for text areas, allowing users to scroll beyond document content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->