### PR TITLE
Add read-only text segments to ATIS sandbox

### DIFF
--- a/vATIS.Desktop/Ui/Common/ReadOnlySegmentTransformer.cs
+++ b/vATIS.Desktop/Ui/Common/ReadOnlySegmentTransformer.cs
@@ -1,0 +1,47 @@
+// <copyright file="ReadOnlySegmentTransformer.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using Avalonia.Media;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
+
+namespace Vatsim.Vatis.Ui.Common;
+
+/// <summary>
+/// A transformer that colorizes read-only segments of a document line.
+/// </summary>
+public class ReadOnlySegmentTransformer : DocumentColorizingTransformer
+{
+    private readonly TextSegmentCollection<TextSegment> _readOnlySegments;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReadOnlySegmentTransformer"/> class.
+    /// </summary>
+    /// <param name="readOnlySegments">The collection of read-only segments to colorize.</param>
+    public ReadOnlySegmentTransformer(TextSegmentCollection<TextSegment> readOnlySegments)
+    {
+        _readOnlySegments = readOnlySegments;
+    }
+
+    /// <summary>
+    /// Colorizes the specified line by applying color to the overlapping read-only segments.
+    /// </summary>
+    /// <param name="line">The document line to colorize.</param>
+    protected override void ColorizeLine(DocumentLine line)
+    {
+        foreach (var segment in _readOnlySegments.FindOverlappingSegments(line.Offset, line.Length))
+        {
+            ChangeLinePart(
+                Math.Max(segment.StartOffset, line.Offset),
+                Math.Min(segment.EndOffset, line.Offset + line.Length),
+                element =>
+                {
+                    element.TextRunProperties.SetForegroundBrush(Brushes.Aqua);
+                }
+            );
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -15,6 +15,7 @@ using AvaloniaEdit.Rendering;
 using ReactiveUI;
 using Serilog;
 using Vatsim.Vatis.Networking;
+using Vatsim.Vatis.Ui.Common;
 using Vatsim.Vatis.Ui.ViewModels;
 
 namespace Vatsim.Vatis.Ui.Components;
@@ -251,30 +252,5 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
         }
 
         _notamsInitialized = true;
-    }
-
-    private class ReadOnlySegmentTransformer : DocumentColorizingTransformer
-    {
-        private readonly TextSegmentCollection<TextSegment> _readOnlySegments;
-
-        public ReadOnlySegmentTransformer(TextSegmentCollection<TextSegment> readOnlySegments)
-        {
-            _readOnlySegments = readOnlySegments;
-        }
-
-        protected override void ColorizeLine(DocumentLine line)
-        {
-            foreach (var segment in _readOnlySegments.FindOverlappingSegments(line.Offset, line.Length))
-            {
-                ChangeLinePart(
-                    Math.Max(segment.StartOffset, line.Offset),
-                    Math.Min(segment.EndOffset, line.Offset + line.Length),
-                    element =>
-                    {
-                        element.TextRunProperties.SetForegroundBrush(Brushes.Aqua);
-                    }
-                );
-            }
-        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced text editing capabilities in the Sandbox view
  - Improved management of read-only text segments in documents

- **Improvements**
  - Added reactive programming support for better user interaction
  - Implemented advanced text document handling for airport conditions and NOTAMs
  - Introduced dynamic read-only segment visualization

- **Technical Enhancements**
  - Updated view and view model to support more flexible text editing
  - Refined text document management with improved nullability and offset tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->