### PR TITLE
Set airport conditions and NOTAMs to empty if hub message is null

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -255,12 +255,12 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                     if (AirportConditionsTextDocument != null)
                     {
-                        AirportConditionsTextDocument.Text = sync.Dto.AirportConditions;
+                        AirportConditionsTextDocument.Text = sync.Dto.AirportConditions ?? "";
                     }
 
                     if (NotamsTextDocument != null)
                     {
-                        NotamsTextDocument.Text = sync.Dto.Notams;
+                        NotamsTextDocument.Text = sync.Dto.Notams ?? "";
                     }
                 });
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for airport conditions and NOTAM text documents by preventing null assignments.
	- Enhanced code stability to avoid potential runtime exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->