### PR TITLE
Fix aws cli incompatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,8 @@ jobs:
           aws configure set aws_secret_access_key "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
           aws configure set region auto
           aws configure set output "json"
+          aws configure set request_checksum_calculation when_required
+          aws configure set response_checksum_validation when_required
 
           # Rename AppImage
           mv ./velopack/org.vatsim.vatis.AppImage ./velopack/vATIS.AppImage
@@ -372,6 +374,8 @@ jobs:
           aws configure set aws_secret_access_key "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
           aws configure set region auto
           aws configure set output "json"
+          aws configure set request_checksum_calculation when_required
+          aws configure set response_checksum_validation when_required
 
           # Upload release assets
           aws s3 sync ./velopack s3://vatis-releases/macos \
@@ -501,6 +505,8 @@ jobs:
           aws configure set aws_secret_access_key "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
           aws configure set region auto
           aws configure set output "json"
+          aws configure set request_checksum_calculation when_required
+          aws configure set response_checksum_validation when_required
 
           # Rename AppImage
           mv ./velopack/org.vatsim.vatis-win-Setup.exe ./velopack/vATIS-Setup.exe


### PR DESCRIPTION
From Cloudflare: the CLI versions 2.23.0 and 1.37.0 introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for AWS CLI uploads
	- Added checksum calculation and validation settings for release asset uploads across Linux, macOS, and Windows environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->