### PR TITLE
Fix duplicate ATIS subscriber notifications

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1132,7 +1132,14 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                     await PublishAtisToWebsocket();
                     await PublishAtisToHub();
-                    _networkConnection?.SendSubscriberNotification(AtisLetter);
+
+                    if (!e.IsNewMetar)
+                    {
+                        // Prevent duplicate subscriber notifications.
+                        // Send notification only when the initial METAR is received upon first connection.
+                        _networkConnection?.SendSubscriberNotification(AtisLetter);
+                    }
+
                     await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
 
                     var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the notifications so that alerts are sent only upon the first update, preventing duplicate notifications and streamlining the alert process for meteorological updates.
  - Enhanced error handling to ensure exceptions are logged and managed appropriately during property updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->