### PR TITLE
Restore saved checkbox value for "include before free text"

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1355,7 +1355,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void PopulateNotams()
     {
-        if (NotamsTextDocument == null)
+        if (NotamsTextDocument == null || SelectedAtisPreset == null)
             return;
 
         // Clear the list of read-only NOTAM text segments.
@@ -1402,7 +1402,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void PopulateAirportConditions()
     {
-        if (AirportConditionsTextDocument == null)
+        if (AirportConditionsTextDocument == null || SelectedAtisPreset == null)
             return;
 
         // Clear the list of read-only NOTAM text segments.

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -691,6 +691,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             viewModel.Definitions = new ObservableCollection<StaticDefinition>(_atisStation.NotamDefinitions);
             viewModel.ContractionCompletionData = ContractionCompletionData;
+            viewModel.IncludeBeforeFreeText = _atisStation.NotamsBeforeFreeText;
 
             viewModel.WhenAnyValue(x => x.IncludeBeforeFreeText).Subscribe(val =>
             {
@@ -742,6 +743,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             viewModel.Definitions = new ObservableCollection<StaticDefinition>(_atisStation.AirportConditionDefinitions);
             viewModel.ContractionCompletionData = ContractionCompletionData;
+            viewModel.IncludeBeforeFreeText = _atisStation.AirportConditionsBeforeFreeText;
 
             viewModel.WhenAnyValue(x => x.IncludeBeforeFreeText).Subscribe(val =>
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option in both the NOTAMs and airport conditions dialogs to include text before free-form entries.
  - Enhanced user control with settings that automatically save your preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->