### PR TITLE
Add support for speech rate multiplier

### DIFF
--- a/vATIS.Desktop/Profiles/Models/AtisVoiceMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisVoiceMeta.cs
@@ -23,7 +23,7 @@ public class AtisVoiceMeta
     /// <summary>
     /// Gets or sets the speech rate multiplier.
     /// </summary>
-    public double SpeechRateMultiplier { get; set; } = 1.0;
+    public int SpeechRate { get; set; } = 180;
 
     /// <summary>
     /// Creates a new instance of <see cref="AtisVoiceMeta"/> that is a copy of the current instance.
@@ -35,7 +35,7 @@ public class AtisVoiceMeta
         {
             UseTextToSpeech = UseTextToSpeech,
             Voice = Voice,
-            SpeechRateMultiplier = SpeechRateMultiplier
+            SpeechRate = SpeechRate
         };
     }
 }

--- a/vATIS.Desktop/Profiles/Models/AtisVoiceMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisVoiceMeta.cs
@@ -21,6 +21,11 @@ public class AtisVoiceMeta
     public string? Voice { get; set; } = "Default";
 
     /// <summary>
+    /// Gets or sets the speech rate multiplier.
+    /// </summary>
+    public double SpeechRateMultiplier { get; set; } = 1.0;
+
+    /// <summary>
     /// Creates a new instance of <see cref="AtisVoiceMeta"/> that is a copy of the current instance.
     /// </summary>
     /// <returns>A new <see cref="AtisVoiceMeta"/> instance that is a copy of this instance.</returns>
@@ -30,6 +35,7 @@ public class AtisVoiceMeta
         {
             UseTextToSpeech = UseTextToSpeech,
             Voice = Voice,
+            SpeechRateMultiplier = SpeechRateMultiplier
         };
     }
 }

--- a/vATIS.Desktop/TextToSpeech/TextToSpeechRequestDto.cs
+++ b/vATIS.Desktop/TextToSpeech/TextToSpeechRequestDto.cs
@@ -26,6 +26,11 @@ public class TextToSpeechRequestDto
     public string? Voice { get; set; }
 
     /// <summary>
+    /// Gets or sets the speech rate multiplier.
+    /// </summary>
+    public double? SpeechRateMultiplier { get; set; }
+
+    /// <summary>
     /// Gets or sets the JSON Web Token (JWT) used for authentication.
     /// </summary>
     public string? Jwt { get; set; }

--- a/vATIS.Desktop/TextToSpeech/TextToSpeechRequestDto.cs
+++ b/vATIS.Desktop/TextToSpeech/TextToSpeechRequestDto.cs
@@ -28,7 +28,7 @@ public class TextToSpeechRequestDto
     /// <summary>
     /// Gets or sets the speech rate multiplier.
     /// </summary>
-    public double? SpeechRateMultiplier { get; set; }
+    public double? SpeechRate { get; set; }
 
     /// <summary>
     /// Gets or sets the JSON Web Token (JWT) used for authentication.

--- a/vATIS.Desktop/TextToSpeech/TextToSpeechService.cs
+++ b/vATIS.Desktop/TextToSpeech/TextToSpeechService.cs
@@ -74,7 +74,7 @@ public class TextToSpeechService : ITextToSpeechService
             {
                 Text = text,
                 Voice = VoiceList.FirstOrDefault(v => v.Name == station.AtisVoice.Voice)?.Id ?? "default",
-                SpeechRateMultiplier = station.AtisVoice.SpeechRateMultiplier,
+                SpeechRate = station.AtisVoice.SpeechRate,
                 Jwt = authToken
             };
 

--- a/vATIS.Desktop/TextToSpeech/TextToSpeechService.cs
+++ b/vATIS.Desktop/TextToSpeech/TextToSpeechService.cs
@@ -74,6 +74,7 @@ public class TextToSpeechService : ITextToSpeechService
             {
                 Text = text,
                 Voice = VoiceList.FirstOrDefault(v => v.Name == station.AtisVoice.Voice)?.Id ?? "default",
+                SpeechRateMultiplier = station.AtisVoice.SpeechRateMultiplier,
                 Jwt = authToken
             };
 

--- a/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
@@ -14,6 +14,7 @@
         <converters:SpeechRateMultiplierConverter x:Key="SpeechRateMultiplierConverter"/>
         <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
 		<converters:CharToStringConverter x:Key="CharToStringConverter"/>
+        <x:String x:Key="SpeechRateTooltip">Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).</x:String>
 	</UserControl.Resources>
 	<StackPanel Spacing="8">
 		<StackPanel>
@@ -116,8 +117,8 @@
 						<RadioButton Theme="{StaticResource RadioButton}" Content="Voice Recorded" IsChecked="{Binding !UseTextToSpeech, DataType=vm:GeneralConfigViewModel}"/>
 					</StackPanel>
                     <StackPanel Orientation="Horizontal" Spacing="15">
-                        <TextBlock VerticalAlignment="Center" ToolTip.Tip="Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).">Speech Rate Multiplier:</TextBlock>
-                        <ComboBox Width="100" Classes="Dark" ItemsSource="{Binding SpeechRates, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding SelectedSpeechRate, DataType=vm:GeneralConfigViewModel}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}" ToolTip.Tip="Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).">
+                        <TextBlock VerticalAlignment="Center" ToolTip.Tip="{StaticResource SpeechRateTooltip}">Speech Rate Multiplier:</TextBlock>
+                        <ComboBox Width="100" Classes="Dark" ItemsSource="{Binding SpeechRates, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding SelectedSpeechRate, DataType=vm:GeneralConfigViewModel}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}" ToolTip.Tip="{StaticResource SpeechRateTooltip}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding ., Converter={StaticResource SpeechRateMultiplierConverter}}"></TextBlock>

--- a/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
@@ -14,7 +14,7 @@
         <converters:SpeechRateMultiplierConverter x:Key="SpeechRateMultiplierConverter"/>
         <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
 		<converters:CharToStringConverter x:Key="CharToStringConverter"/>
-        <x:String x:Key="SpeechRateTooltip">Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).</x:String>
+        <x:String x:Key="SpeechRateTooltip">Select a speech rate to control voice ATIS speed. 180 WPM (words per minute) is the default. Lower values slow down speech, while higher values speed it up.</x:String>
 	</UserControl.Resources>
 	<StackPanel Spacing="8">
 		<StackPanel>
@@ -116,15 +116,9 @@
 						<ComboBox Width="280" Classes="Dark" HorizontalAlignment="Stretch" ItemsSource="{Binding AvailableVoices, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding TextToSpeechVoice, DataType=vm:GeneralConfigViewModel}" DisplayMemberBinding="{Binding Name, DataType=tts:VoiceMetaData}" SelectedValueBinding="{Binding Name, DataType=tts:VoiceMetaData}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}"/>
 						<RadioButton Theme="{StaticResource RadioButton}" Content="Voice Recorded" IsChecked="{Binding !UseTextToSpeech, DataType=vm:GeneralConfigViewModel}"/>
 					</StackPanel>
-                    <StackPanel Orientation="Horizontal" Spacing="15">
-                        <TextBlock VerticalAlignment="Center" ToolTip.Tip="{StaticResource SpeechRateTooltip}">Speech Rate Multiplier:</TextBlock>
-                        <ComboBox Width="100" Classes="Dark" ItemsSource="{Binding SpeechRates, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding SelectedSpeechRate, DataType=vm:GeneralConfigViewModel}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}" ToolTip.Tip="{StaticResource SpeechRateTooltip}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding ., Converter={StaticResource SpeechRateMultiplierConverter}}"></TextBlock>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                    <StackPanel Orientation="Horizontal" Spacing="13">
+                        <TextBlock VerticalAlignment="Center" ToolTip.Tip="{StaticResource SpeechRateTooltip}">Speech Rate (WPM):</TextBlock>
+                        <ComboBox Width="100" Classes="Dark" ItemsSource="{Binding SpeechRates, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding SelectedSpeechRate, DataType=vm:GeneralConfigViewModel}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}" ToolTip.Tip="{StaticResource SpeechRateTooltip}"/>
                     </StackPanel>
 					<CheckBox Theme="{StaticResource CheckBox}" Content="Use &quot;decimal&quot; terminology in spoken text" ToolTip.Tip="Spoken decimal numbers will be spoken using &quot;decimal&quot; instead of &quot;point&quot; (e.g. one two one decimal three five)." IsChecked="{Binding UseDecimalTerminology, DataType=vm:GeneralConfigViewModel}" />
 				</StackPanel>

--- a/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/GeneralConfigView.axaml
@@ -11,7 +11,8 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Vatsim.Vatis.Ui.AtisConfiguration.GeneralConfigView">
 	<UserControl.Resources>
-		<converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
+        <converters:SpeechRateMultiplierConverter x:Key="SpeechRateMultiplierConverter"/>
+        <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
 		<converters:CharToStringConverter x:Key="CharToStringConverter"/>
 	</UserControl.Resources>
 	<StackPanel Spacing="8">
@@ -23,7 +24,7 @@
 						<Interaction.Behaviors>
 							<behaviors:VhfFrequencyFormatBehavior/>
 							<behaviors:SelectAllTextOnFocusBehavior/>
-						</Interaction.Behaviors>										
+						</Interaction.Behaviors>
 					</TextBox>
 				</StackPanel>
 			</Border>
@@ -114,6 +115,16 @@
 						<ComboBox Width="280" Classes="Dark" HorizontalAlignment="Stretch" ItemsSource="{Binding AvailableVoices, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding TextToSpeechVoice, DataType=vm:GeneralConfigViewModel}" DisplayMemberBinding="{Binding Name, DataType=tts:VoiceMetaData}" SelectedValueBinding="{Binding Name, DataType=tts:VoiceMetaData}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}"/>
 						<RadioButton Theme="{StaticResource RadioButton}" Content="Voice Recorded" IsChecked="{Binding !UseTextToSpeech, DataType=vm:GeneralConfigViewModel}"/>
 					</StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="15">
+                        <TextBlock VerticalAlignment="Center" ToolTip.Tip="Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).">Speech Rate Multiplier:</TextBlock>
+                        <ComboBox Width="100" Classes="Dark" ItemsSource="{Binding SpeechRates, DataType=vm:GeneralConfigViewModel}" SelectedValue="{Binding SelectedSpeechRate, DataType=vm:GeneralConfigViewModel}" IsEnabled="{Binding UseTextToSpeech, DataType=vm:GeneralConfigViewModel, FallbackValue=False}" ToolTip.Tip="Adjust the speech speed. Choose from: 0.5x (slowest), 0.75x (slower), 1x (normal), 1.25x (faster), and 1.5x (fastest).">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding ., Converter={StaticResource SpeechRateMultiplierConverter}}"></TextBlock>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
 					<CheckBox Theme="{StaticResource CheckBox}" Content="Use &quot;decimal&quot; terminology in spoken text" ToolTip.Tip="Spoken decimal numbers will be spoken using &quot;decimal&quot; instead of &quot;point&quot; (e.g. one two one decimal three five)." IsChecked="{Binding UseDecimalTerminology, DataType=vm:GeneralConfigViewModel}" />
 				</StackPanel>
 			</Border>

--- a/vATIS.Desktop/Ui/Converters/SpeechRateMultiplierConverter.cs
+++ b/vATIS.Desktop/Ui/Converters/SpeechRateMultiplierConverter.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Vatsim.Vatis.Ui.Converters;
+
+/// <summary>
+/// Converts a numeric speech rate (e.g., 0.5) to a formatted string (e.g., "0.5x").
+/// </summary>
+public class SpeechRateMultiplierConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a double value representing the speech rate to a formatted string (e.g., "0.5x").
+    /// </summary>
+    /// <param name="value">The value to convert (expected to be a double representing the speech rate).</param>
+    /// <param name="targetType">The target type (not used in this implementation).</param>
+    /// <param name="parameter">Any optional parameters (not used in this implementation).</param>
+    /// <param name="culture">The culture info (not used in this implementation).</param>
+    /// <returns>A string formatted as the speech rate with an 'x' suffix (e.g., "1.0x").</returns>
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is double rate)
+        {
+            return $"{rate}x"; // Format as 0.5x, 1.0x, etc.
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Converts a formatted string (e.g., "0.5x") back to a double value representing the speech rate.
+    /// </summary>
+    /// <param name="value">The value to convert (expected to be a string formatted as "0.5x").</param>
+    /// <param name="targetType">The target type (expected to be a double).</param>
+    /// <param name="parameter">Any optional parameters (not used in this implementation).</param>
+    /// <param name="culture">The culture info (not used in this implementation).</param>
+    /// <returns>A double representing the speech rate (e.g., 0.5).</returns>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        // If converting back (e.g., from "0.5x" to 0.5), remove the "x" and parse the number.
+        if (value is string rateString && double.TryParse(rateString.Replace("x", ""), out var result))
+        {
+            return result;
+        }
+
+        return value;
+    }
+}

--- a/vATIS.Desktop/Ui/Converters/SpeechRateMultiplierConverter.cs
+++ b/vATIS.Desktop/Ui/Converters/SpeechRateMultiplierConverter.cs
@@ -19,9 +19,12 @@ public class SpeechRateMultiplierConverter : IValueConverter
     /// <returns>A string formatted as the speech rate with an 'x' suffix (e.g., "1.0x").</returns>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        if (value is null)
+            return null;
+
         if (value is double rate)
         {
-            return $"{rate}x"; // Format as 0.5x, 1.0x, etc.
+            return $"{rate.ToString(CultureInfo.InvariantCulture)}x"; // Format as 0.5x, 1.0x, etc.
         }
 
         return value;
@@ -37,8 +40,12 @@ public class SpeechRateMultiplierConverter : IValueConverter
     /// <returns>A double representing the speech rate (e.g., 0.5).</returns>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        if (value is null)
+            return null;
+
         // If converting back (e.g., from "0.5x" to 0.5), remove the "x" and parse the number.
-        if (value is string rateString && double.TryParse(rateString.Replace("x", ""), out var result))
+        if (value is string rateString &&
+            double.TryParse(rateString.Replace("x", ""), CultureInfo.InvariantCulture, out var result))
         {
             return result;
         }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -252,7 +252,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets the available speech rate multipliers.
     /// </summary>
-    public ObservableCollection<double> SpeechRates { get; } = [0.5, 0.75, 1.0, 1.25, 1.5];
+    public ObservableCollection<double> SpeechRates { get; } = new(s_allowedSpeechRates);
 
     /// <summary>
     /// Gets or sets the selected speech rate multiplier.

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -27,6 +27,7 @@ namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
 {
     private static readonly double[] s_allowedSpeechRates = [0.5, 0.75, 1.0, 1.25, 1.5];
+    private static readonly HashSet<double> s_allowedSpeechRatesSet = new(s_allowedSpeechRates);
     private readonly CompositeDisposable _disposables = [];
     private readonly HashSet<string> _initializedProperties = [];
     private readonly IProfileRepository _profileRepository;
@@ -400,8 +401,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
         if (Math.Abs(SelectedStation.AtisVoice.SpeechRateMultiplier - SelectedSpeechRate) > 0.0001)
         {
             // Ensure SelectedSpeechRate is one of the valid options
-            SelectedStation.AtisVoice.SpeechRateMultiplier = Array.Exists(s_allowedSpeechRates,
-                rate => Math.Abs(rate - SelectedSpeechRate) < 0.0001)
+            SelectedStation.AtisVoice.SpeechRateMultiplier = s_allowedSpeechRatesSet.Contains(SelectedSpeechRate)
                 ? SelectedSpeechRate
                 : 1.0; // If not valid, set to 1.0
         }
@@ -443,8 +443,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
         TextToSpeechVoice = station.AtisVoice.Voice;
 
         // Ensure the speech rate is one of the allowed values: 0.5, 0.75, 1.0, 1.25, 1.5
-        SelectedSpeechRate = Array.Exists(s_allowedSpeechRates,
-            rate => Math.Abs(rate - station.AtisVoice.SpeechRateMultiplier) < 0.0001)
+        SelectedSpeechRate = s_allowedSpeechRatesSet.Contains(station.AtisVoice.SpeechRateMultiplier)
             ? station.AtisVoice.SpeechRateMultiplier
             : 1.0; // Default value if the rate is not allowed
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -26,8 +26,7 @@ namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 /// </summary>
 public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
 {
-    private static readonly double[] s_allowedSpeechRates = [0.5, 0.75, 1.0, 1.25, 1.5];
-    private static readonly HashSet<double> s_allowedSpeechRatesSet = new(s_allowedSpeechRates);
+    private static readonly int[] s_allowedSpeechRates = [120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240];
     private readonly CompositeDisposable _disposables = [];
     private readonly HashSet<string> _initializedProperties = [];
     private readonly IProfileRepository _profileRepository;
@@ -46,7 +45,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
     private string? _idsEndpoint;
     private ObservableCollection<VoiceMetaData>? _availableVoices;
     private bool _showDuplicateAtisTypeError;
-    private double _selectedSpeechRate;
+    private int _selectedSpeechRate;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GeneralConfigViewModel"/> class.
@@ -253,12 +252,12 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets the available speech rate multipliers.
     /// </summary>
-    public ObservableCollection<double> SpeechRates { get; } = new(s_allowedSpeechRates);
+    public ObservableCollection<int> SpeechRates { get; } = new(s_allowedSpeechRates);
 
     /// <summary>
     /// Gets or sets the selected speech rate multiplier.
     /// </summary>
-    public double SelectedSpeechRate
+    public int SelectedSpeechRate
     {
         get => _selectedSpeechRate;
         set
@@ -398,12 +397,10 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisVoice.Voice = TextToSpeechVoice;
         }
 
-        if (Math.Abs(SelectedStation.AtisVoice.SpeechRateMultiplier - SelectedSpeechRate) > 0.0001)
+        if (SelectedStation.AtisVoice.SpeechRate != SelectedSpeechRate)
         {
-            // Ensure SelectedSpeechRate is one of the valid options
-            SelectedStation.AtisVoice.SpeechRateMultiplier = s_allowedSpeechRatesSet.Contains(SelectedSpeechRate)
-                ? SelectedSpeechRate
-                : 1.0; // If not valid, set to 1.0
+            SelectedStation.AtisVoice.SpeechRate =
+                s_allowedSpeechRates.Contains(SelectedSpeechRate) ? SelectedSpeechRate : 180;
         }
 
         if (HasErrors || ShowDuplicateAtisTypeError)
@@ -442,10 +439,10 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
         UseTextToSpeech = station.AtisVoice.UseTextToSpeech;
         TextToSpeechVoice = station.AtisVoice.Voice;
 
-        // Ensure the speech rate is one of the allowed values: 0.5, 0.75, 1.0, 1.25, 1.5
-        SelectedSpeechRate = s_allowedSpeechRatesSet.Contains(station.AtisVoice.SpeechRateMultiplier)
-            ? station.AtisVoice.SpeechRateMultiplier
-            : 1.0; // Default value if the rate is not allowed
+        // Ensure speech rate is a valid value.
+        SelectedSpeechRate = s_allowedSpeechRates.Contains(station.AtisVoice.SpeechRate)
+            ? station.AtisVoice.SpeechRate
+            : 180; // Fallback to default speech rate value.
 
         HasUnsavedChanges = false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an adjustable speech rate multiplier for text-to-speech audio, allowing users to personalize playback speed.
  - Added a new dropdown in the settings interface with descriptive tooltips for easy selection of available speech rates.
  - Enhanced the configuration capabilities to manage speech rates effectively, ensuring consistency across all audio interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->