### PR TITLE
Show release notes after installing update

### DIFF
--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -18,6 +18,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveUI;
 using Sentry;
 using Serilog;
@@ -29,11 +30,13 @@ using Vatsim.Vatis.NavData;
 using Vatsim.Vatis.Profiles;
 using Vatsim.Vatis.Sessions;
 using Vatsim.Vatis.TextToSpeech;
+using Vatsim.Vatis.Ui.Dialogs;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
 using Vatsim.Vatis.Ui.Startup;
 using Vatsim.Vatis.Ui.ViewModels;
 using Vatsim.Vatis.Updates;
 using Vatsim.Vatis.Voice.Audio;
+using Velopack.Locators;
 
 namespace Vatsim.Vatis;
 
@@ -179,6 +182,23 @@ public class App : Application
                 await CheckForProfileUpdatesAsync();
                 await UpdateNavDataAsync();
                 await UpdateAvailableVoicesAsync();
+
+                // Show release notes of new version
+                if (arguments.TryGetValue("--isUpdated", out _))
+                {
+                    var locator = VelopackLocator.GetDefault(NullLogger.Instance);
+                    var currentRelease = locator.GetLocalPackages()
+                        .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
+                    if (currentRelease?.NotesMarkdown != null)
+                    {
+                        var releaseNotes = _serviceProvider.GetService<ReleaseNotesDialog>();
+                        if (releaseNotes.ViewModel != null)
+                        {
+                            releaseNotes.ViewModel.ReleaseNotes = currentRelease.NotesMarkdown;
+                            await releaseNotes.ShowDialog(_startupWindow);
+                        }
+                    }
+                }
 
                 _startupWindow.Close();
 

--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -186,17 +186,24 @@ public class App : Application
                 // Show release notes of new version
                 if (arguments.TryGetValue("--isUpdated", out _))
                 {
-                    var locator = VelopackLocator.GetDefault(NullLogger.Instance);
-                    var currentRelease = locator.GetLocalPackages()
-                        .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
-                    if (currentRelease?.NotesMarkdown != null)
+                    try
                     {
-                        var releaseNotes = _serviceProvider.GetService<ReleaseNotesDialog>();
-                        if (releaseNotes.ViewModel != null)
+                        var locator = VelopackLocator.GetDefault(NullLogger.Instance);
+                        var currentRelease = locator.GetLocalPackages()
+                            .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
+                        if (currentRelease?.NotesMarkdown != null)
                         {
-                            releaseNotes.ViewModel.ReleaseNotes = currentRelease.NotesMarkdown;
-                            await releaseNotes.ShowDialog(_startupWindow);
+                            var releaseNotes = _serviceProvider.GetService<ReleaseNotesDialog>();
+                            if (releaseNotes.ViewModel != null)
+                            {
+                                releaseNotes.ViewModel.ReleaseNotes = currentRelease.NotesMarkdown;
+                                await releaseNotes.ShowDialog(_startupWindow);
+                            }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error showing release notes.");
                     }
                 }
 

--- a/vATIS.Desktop/Container/Factory/WindowFactory.cs
+++ b/vATIS.Desktop/Container/Factory/WindowFactory.cs
@@ -196,4 +196,14 @@ internal class WindowFactory : IWindowFactory
         var viewModel = _provider.GetService<SortPresetsDialogViewModel>();
         return new SortPresetsDialog(viewModel);
     }
+
+    /// <summary>
+    /// Creates and initializes a new instance of the <see cref="ReleaseNotesDialog"/> class.
+    /// </summary>
+    /// <returns>An instance of the <see cref="ReleaseNotesDialog"/> class.</returns>
+    public ReleaseNotesDialog CreateReleaseNotesDialog()
+    {
+        var viewModel = _provider.GetService<ReleaseNotesDialogViewModel>();
+        return new ReleaseNotesDialog(viewModel);
+    }
 }

--- a/vATIS.Desktop/Container/ServiceProvider.cs
+++ b/vATIS.Desktop/Container/ServiceProvider.cs
@@ -72,6 +72,7 @@ namespace Vatsim.Vatis.Container;
 [Transient(typeof(UserInputDialog))]
 [Transient(typeof(MessageBoxView))]
 [Transient(typeof(SortPresetsDialog))]
+[Transient(typeof(ReleaseNotesDialog))]
 
 // ViewModels
 [Transient(typeof(ProfileListViewModel))]
@@ -96,6 +97,7 @@ namespace Vatsim.Vatis.Container;
 [Transient(typeof(GeneralConfigViewModel))]
 [Transient(typeof(PresetsViewModel))]
 [Transient(typeof(SandboxViewModel))]
+[Transient(typeof(ReleaseNotesDialogViewModel))]
 internal sealed partial class ServiceProvider
 {
     /// <summary>

--- a/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
@@ -15,7 +15,7 @@
         SystemDecorations="None"
         TransparencyLevelHint="Transparent"
         Background="Transparent">
-    <Border BorderBrush="#646464" BorderThickness="1" Background="#1E1E1E" CornerRadius="5" Opacity="0.95">
+    <Border BorderBrush="#646464" BorderThickness="1" Background="#1E1E1E" CornerRadius="5">
         <Grid RowDefinitions="*,10,Auto" Margin="15">
             <mdxaml:MarkdownScrollViewer Grid.Row="0" Margin="0 -10 0 0" Markdown="{Binding ReleaseNotes, DataType=vm:ReleaseNotesDialogViewModel}">
                 <mdxaml:MarkdownScrollViewer.Styles>

--- a/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
@@ -1,0 +1,36 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia"
+        xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
+        xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="Vatsim.Vatis.Ui.Dialogs.ReleaseNotesDialog"
+        Title="Release Notes"
+        Width="600" Height="500"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+    <Border BorderBrush="#646464" BorderThickness="1" Background="#1E1E1E" CornerRadius="5" Opacity="0.95">
+        <Grid RowDefinitions="*,10,Auto" Margin="15">
+            <mdxaml:MarkdownScrollViewer Grid.Row="0" Margin="0 -10 0 0" Markdown="{Binding ReleaseNotes, DataType=vm:ReleaseNotesDialogViewModel}">
+                <mdxaml:MarkdownScrollViewer.Styles>
+                    <Style Selector="ctxt|CTextBlock.Heading1">
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="FontSize" Value="28"/>
+                        <Setter Property="HorizontalAlignment" Value="Center"/>
+                    </Style>
+                    <Style Selector=".List ctxt|CTextBlock">
+                        <Setter Property="FontSize" Value="18"/>
+                    </Style>
+                </mdxaml:MarkdownScrollViewer.Styles>
+            </mdxaml:MarkdownScrollViewer>
+            <Button Grid.Row="2" Theme="{StaticResource Dark}" FontSize="24" HorizontalAlignment="Stretch" Content="CLOSE" Click="CloseWindow"/>
+        </Grid>
+    </Border>
+</Window>
+

--- a/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml.cs
@@ -1,0 +1,31 @@
+// <copyright file="ReleaseNotesDialog.axaml.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using Avalonia.Interactivity;
+using Avalonia.ReactiveUI;
+using Vatsim.Vatis.Ui.ViewModels;
+
+namespace Vatsim.Vatis.Ui.Dialogs;
+
+/// <summary>
+/// Represents a dialog that displays the release notes for the installed version.
+/// </summary>
+public partial class ReleaseNotesDialog : ReactiveWindow<ReleaseNotesDialogViewModel>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReleaseNotesDialog"/> class.
+    /// </summary>
+    /// <param name="viewModel">The view model associated with the view.</param>
+    public ReleaseNotesDialog(ReleaseNotesDialogViewModel viewModel)
+    {
+        InitializeComponent();
+        ViewModel = viewModel;
+    }
+
+    private void CloseWindow(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/vATIS.Desktop/Ui/IWindowFactory.cs
+++ b/vATIS.Desktop/Ui/IWindowFactory.cs
@@ -97,4 +97,10 @@ public interface IWindowFactory
     /// </summary>
     /// <returns>An instance of the <see cref="SortPresetsDialog"/> class.</returns>
     SortPresetsDialog CreateSortPresetsDialog();
+
+    /// <summary>
+    /// Creates and initializes a new instance of the <see cref="ReleaseNotesDialog"/> class.
+    /// </summary>
+    /// <returns>An instance of the <see cref="ReleaseNotesDialog"/> class.</returns>
+    ReleaseNotesDialog CreateReleaseNotesDialog();
 }

--- a/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
+++ b/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
@@ -72,7 +72,13 @@
 			</DockPanel>
 			<DockPanel Grid.Row="2">
 				<Border BorderBrush="#646464" BorderThickness="0,1,0,0">
-					<TextBlock Foreground="White" Text="{Binding ClientVersion, DataType=vm:ProfileListViewModel}" Margin="5,3" TextAlignment="Center" VerticalAlignment="Center" />
+					<TextBlock Name="Version" Foreground="White" Text="{Binding ClientVersion, DataType=vm:ProfileListViewModel}" Margin="5,3" TextAlignment="Center" VerticalAlignment="Center" Cursor="Hand">
+                        <Interaction.Behaviors>
+                            <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="Version">
+                                <InvokeCommandAction Command="{Binding OpenReleaseNotesCommand, DataType=vm:ProfileListViewModel}"/>
+                            </RoutedEventTriggerBehavior>
+                        </Interaction.Behaviors>
+                    </TextBlock>
 				</Border>
 			</DockPanel>
 		</Grid>

--- a/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
+++ b/vATIS.Desktop/Ui/Profiles/ProfileListDialog.axaml
@@ -72,7 +72,7 @@
 			</DockPanel>
 			<DockPanel Grid.Row="2">
 				<Border BorderBrush="#646464" BorderThickness="0,1,0,0">
-					<TextBlock Name="Version" Foreground="White" Text="{Binding ClientVersion, DataType=vm:ProfileListViewModel}" Margin="5,3" TextAlignment="Center" VerticalAlignment="Center" Cursor="Hand">
+					<TextBlock Name="Version" Foreground="White" Text="{Binding ClientVersion, DataType=vm:ProfileListViewModel}" Margin="5,3" TextAlignment="Center" VerticalAlignment="Center" Cursor="Hand" ToolTip.Tip="Click to view release notes">
                         <Interaction.Behaviors>
                             <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="Version">
                                 <InvokeCommandAction Command="{Binding OpenReleaseNotesCommand, DataType=vm:ProfileListViewModel}"/>

--- a/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
@@ -18,6 +19,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using DynamicData;
 using DynamicData.Binding;
+using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveUI;
 using Serilog;
 using Vatsim.Vatis.Profiles;
@@ -27,6 +29,7 @@ using Vatsim.Vatis.Ui.Dialogs;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
 using Vatsim.Vatis.Ui.Services;
 using Vatsim.Vatis.Utils;
+using Velopack.Locators;
 
 namespace Vatsim.Vatis.Ui.ViewModels;
 
@@ -78,6 +81,7 @@ public class ProfileListViewModel : ReactiveViewModelBase, IDisposable
         DeleteProfileCommand = ReactiveCommand.CreateFromTask<ProfileViewModel>(HandleDeleteProfile, canExecute);
         StartClientSessionCommand = ReactiveCommand.Create<ProfileViewModel>(HandleStartSession, canExecute);
         ExitCommand = ReactiveCommand.Create(HandleExit);
+        OpenReleaseNotesCommand = ReactiveCommand.Create(HandleOpenReleaseNotes);
 
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
         {
@@ -134,6 +138,11 @@ public class ProfileListViewModel : ReactiveViewModelBase, IDisposable
     /// Gets the command that handles application exit functionality.
     /// </summary>
     public ReactiveCommand<Unit, Unit> ExitCommand { get; }
+
+    /// <summary>
+    /// Gets the command that opens the release notes for the installed version.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> OpenReleaseNotesCommand { get; }
 
     /// <summary>
     /// Gets or sets the collection of profiles.
@@ -208,6 +217,7 @@ public class ProfileListViewModel : ReactiveViewModelBase, IDisposable
         ExportProfileCommand.Dispose();
         StartClientSessionCommand.Dispose();
         ExitCommand.Dispose();
+        OpenReleaseNotesCommand.Dispose();
     }
 
     private async Task Initialize()
@@ -386,5 +396,28 @@ public class ProfileListViewModel : ReactiveViewModelBase, IDisposable
         {
             Dispatcher.UIThread.Invoke(() => desktop.Shutdown());
         }
+    }
+
+    private void HandleOpenReleaseNotes()
+    {
+        if (_dialogOwner == null)
+            return;
+
+        var locator = VelopackLocator.GetDefault(NullLogger.Instance);
+        var currentRelease = locator.GetLocalPackages()
+            .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
+        var releaseNotes = currentRelease?.NotesMarkdown;
+
+        if (string.IsNullOrEmpty(releaseNotes))
+            return;
+
+        var dialog = _windowFactory.CreateReleaseNotesDialog();
+
+        if (dialog.ViewModel != null)
+        {
+            dialog.ViewModel.ReleaseNotes = releaseNotes;
+        }
+
+        dialog.ShowDialog((Window)_dialogOwner);
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ProfileListViewModel.cs
@@ -403,21 +403,28 @@ public class ProfileListViewModel : ReactiveViewModelBase, IDisposable
         if (_dialogOwner == null)
             return;
 
-        var locator = VelopackLocator.GetDefault(NullLogger.Instance);
-        var currentRelease = locator.GetLocalPackages()
-            .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
-        var releaseNotes = currentRelease?.NotesMarkdown;
-
-        if (string.IsNullOrEmpty(releaseNotes))
-            return;
-
-        var dialog = _windowFactory.CreateReleaseNotesDialog();
-
-        if (dialog.ViewModel != null)
+        try
         {
-            dialog.ViewModel.ReleaseNotes = releaseNotes;
-        }
+            var locator = VelopackLocator.GetDefault(NullLogger.Instance);
+            var currentRelease = locator.GetLocalPackages()
+                .FirstOrDefault(x => x.Version == locator.CurrentlyInstalledVersion);
+            var releaseNotes = currentRelease?.NotesMarkdown;
 
-        dialog.ShowDialog((Window)_dialogOwner);
+            if (string.IsNullOrEmpty(releaseNotes))
+                return;
+
+            var dialog = _windowFactory.CreateReleaseNotesDialog();
+
+            if (dialog.ViewModel != null)
+            {
+                dialog.ViewModel.ReleaseNotes = releaseNotes;
+            }
+
+            dialog.ShowDialog((Window)_dialogOwner);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error opening release notes");
+        }
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
@@ -1,3 +1,8 @@
+// <copyright file="ReleaseNotesDialogViewModel.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
 using ReactiveUI;
 using Vatsim.Vatis.Ui.Dialogs;
 
@@ -18,7 +23,7 @@ public class ReleaseNotesDialogViewModel : ReactiveViewModelBase
     }
 
     /// <summary>
-    /// Gets or sets the release notes markdown text.
+    /// Gets or sets the release notes Markdown text.
     /// </summary>
     public string? ReleaseNotes
     {

--- a/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
@@ -1,0 +1,28 @@
+using ReactiveUI;
+using Vatsim.Vatis.Ui.Dialogs;
+
+namespace Vatsim.Vatis.Ui.ViewModels;
+
+/// <summary>
+/// Represents the view model for the <see cref="ReleaseNotesDialog"/>.
+/// </summary>
+public class ReleaseNotesDialogViewModel : ReactiveViewModelBase
+{
+    private string? _releaseNotes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReleaseNotesDialogViewModel"/> class.
+    /// </summary>
+    public ReleaseNotesDialogViewModel()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the release notes markdown text.
+    /// </summary>
+    public string? ReleaseNotes
+    {
+        get => _releaseNotes;
+        set => this.RaiseAndSetIfChanged(ref _releaseNotes, value);
+    }
+}

--- a/vATIS.Desktop/Updates/ClientUpdater.cs
+++ b/vATIS.Desktop/Updates/ClientUpdater.cs
@@ -65,7 +65,8 @@ public class ClientUpdater : IClientUpdater
 
         if (_updateInfo == null) return false;
         await _updateManager.DownloadUpdatesAsync(_updateInfo, ReportProgress);
-        await _updateManager.WaitExitThenApplyUpdatesAsync(_updateInfo, silent: true);
+        await _updateManager.WaitExitThenApplyUpdatesAsync(_updateInfo, silent: true,
+            restartArgs: ["--isUpdated"]);
 
         return true;
     }

--- a/vATIS.Desktop/vATIS.Desktop.csproj
+++ b/vATIS.Desktop/vATIS.Desktop.csproj
@@ -61,6 +61,7 @@
 		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
 		<PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.0.1" />
 		<PackageReference Include="Concentus" Version="2.2.2" />
+		<PackageReference Include="Markdown.Avalonia" Version="11.0.3-a1" />
 		<PackageReference Include="MessagePack" Version="3.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.11" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release notes are now displayed after updates, triggered by a specific update flag.
  - Introduced an interactive release notes dialog with formatted Markdown content and a “CLOSE” button.
  - The client version text is now clickable, enabling users to open the release notes at any time.
  - Added a command to open release notes directly from the profile view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->