### PR TITLE
Add support for customizing display order of ATIS stations

### DIFF
--- a/vATIS.Desktop/Container/Factory/WindowFactory.cs
+++ b/vATIS.Desktop/Container/Factory/WindowFactory.cs
@@ -196,4 +196,16 @@ internal class WindowFactory : IWindowFactory
         var viewModel = _provider.GetService<SortPresetsDialogViewModel>();
         return new SortPresetsDialog(viewModel);
     }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="SortAtisStationsDialog"/> class.
+    /// </summary>
+    /// <returns>
+    /// A new instance of the <see cref="SortAtisStationsDialog"/> class.
+    /// </returns>
+    public SortAtisStationsDialog CreateSortAtisStationsDialog()
+    {
+        var viewModel = _provider.GetService<SortAtisStationsDialogViewModel>();
+        return new SortAtisStationsDialog(viewModel);
+    }
 }

--- a/vATIS.Desktop/Container/ServiceProvider.cs
+++ b/vATIS.Desktop/Container/ServiceProvider.cs
@@ -72,6 +72,7 @@ namespace Vatsim.Vatis.Container;
 [Transient(typeof(UserInputDialog))]
 [Transient(typeof(MessageBoxView))]
 [Transient(typeof(SortPresetsDialog))]
+[Transient(typeof(SortAtisStationsDialog))]
 
 // ViewModels
 [Transient(typeof(ProfileListViewModel))]
@@ -96,6 +97,7 @@ namespace Vatsim.Vatis.Container;
 [Transient(typeof(GeneralConfigViewModel))]
 [Transient(typeof(PresetsViewModel))]
 [Transient(typeof(SandboxViewModel))]
+[Transient(typeof(SortAtisStationsDialogViewModel))]
 internal sealed partial class ServiceProvider
 {
     /// <summary>

--- a/vATIS.Desktop/Events/AtisStationOrdinalChanged.cs
+++ b/vATIS.Desktop/Events/AtisStationOrdinalChanged.cs
@@ -1,0 +1,17 @@
+// <copyright file="AtisStationOrdinalChanged.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Events;
+
+/// <summary>
+/// Represents an event that is triggered when the ordinal position of an ATIS station is updated.
+/// </summary>
+/// <param name="Id">
+/// The unique identifier of the ATIS station whose ordinal has changed.
+/// </param>
+/// <param name="NewOrdinal">
+/// The updated ordinal position of the ATIS station after the change.
+/// </param>
+public record AtisStationOrdinalChanged(string Id, int NewOrdinal) : IEvent;

--- a/vATIS.Desktop/Profiles/Models/AtisStation.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisStation.cs
@@ -25,6 +25,11 @@ public class AtisStation : ReactiveObject
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
     /// <summary>
+    /// Gets or sets the display ordinal.
+    /// </summary>
+    public int Ordinal { get; set; }
+
+    /// <summary>
     /// Gets or sets the identifier of the ATIS station.
     /// </summary>
     public required string Identifier { get; set; }

--- a/vATIS.Desktop/Ui/Behaviors/ScrollToSelectedItemBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/ScrollToSelectedItemBehavior.cs
@@ -1,0 +1,74 @@
+// <copyright file="ScrollToSelectedItemBehavior.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactions.Custom;
+using ReactiveUI;
+
+namespace Vatsim.Vatis.Ui.Behaviors;
+
+/// <summary>
+/// Behavior that automatically scrolls a <see cref="TreeDataGrid"/> to ensure the selected item is visible.
+/// </summary>
+public class ScrollToSelectedItemBehavior : AttachedToVisualTreeBehavior<TreeDataGrid>
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Attaches to the visual tree and subscribes to the selection change event
+    /// to scroll the selected item into view.
+    /// </summary>
+    /// <param name="disposable">A composite disposable to manage subscriptions.</param>
+    protected override void OnAttachedToVisualTree(CompositeDisposable disposable)
+    {
+        if (AssociatedObject is { RowSelection: { } rowSelection })
+        {
+            Observable.FromEventPattern(rowSelection, nameof(rowSelection.SelectionChanged))
+                .Select(_ =>
+                {
+                    // Retrieve the first selected index.
+                    var selectedIndexPath = rowSelection.SelectedIndex.FirstOrDefault();
+                    if (AssociatedObject.Rows is null)
+                    {
+                        return selectedIndexPath;
+                    }
+
+                    // Convert the logical index to the actual row index in the UI.
+                    var rowIndex = AssociatedObject.Rows.ModelIndexToRowIndex(selectedIndexPath);
+
+                    // Adjust the index if the selected item is a child of a parent row.
+                    if (rowSelection.SelectedIndex.Count > 1)
+                    {
+                        // Skip the first index (parent), sum the child indices, and adjust.
+                        rowIndex += rowSelection.SelectedIndex.Skip(1).Sum();
+
+                        // Add 1 to correct the index for proper positioning.
+                        rowIndex += 1;
+                    }
+
+                    return rowIndex;
+                })
+                .WhereNotNull()
+                .Do(ScrollToItemIndex)
+                .Subscribe()
+                .DisposeWith(disposable);
+        }
+    }
+
+    /// <summary>
+    /// Scrolls the <see cref="TreeDataGrid"/> to bring the specified row index into view.
+    /// </summary>
+    /// <param name="index">The index of the row to bring into view.</param>
+    private void ScrollToItemIndex(int index)
+    {
+        if (AssociatedObject is { RowsPresenter: { } rowsPresenter })
+        {
+            rowsPresenter.BringIntoView(index);
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
@@ -27,7 +27,7 @@
 						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:SortAtisStationsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>
 					</Grid>
 				</Border>
-				<Grid ColumnDefinitions="1*,10,80" Margin="20">
+				<Grid ColumnDefinitions="1*,10,100" Margin="20">
 					<TreeDataGrid Grid.Column="0" CornerRadius="5" BorderBrush="#646464" BorderThickness="1" MaxHeight="200" Source="{Binding Source, DataType=vm:SortAtisStationsDialogViewModel, Mode=OneWay}" CanUserResizeColumns="False" CanUserSortColumns="False">
 						<TreeDataGrid.Styles>
 							<Style Selector="TreeDataGrid /template/ Border#ColumnHeadersPresenterBorder">

--- a/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
@@ -4,9 +4,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
         xmlns:behaviors="clr-namespace:Vatsim.Vatis.Ui.Behaviors"
-        mc:Ignorable="d"
-        x:Class="Vatsim.Vatis.Ui.Dialogs.SortPresetsDialog"
-        Title="SortPresetsDialog"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="Vatsim.Vatis.Ui.Dialogs.SortAtisStationsDialog"
+        Title="SortAtisStationsDialog"
         x:Name="Window"
         Width="570" MaxHeight="325"
         SizeToContent="Height"
@@ -16,7 +16,7 @@
         SystemDecorations="None"
         TransparencyLevelHint="Transparent"
         Background="Transparent">
-	<Window.Resources>
+    <Window.Resources>
 		<SolidColorBrush x:Key="TreeDataGridSelectedCellBackgroundBrush" Color="Black" Opacity="0.3" />
 	</Window.Resources>
 	<Border BorderBrush="#646464" BorderThickness="1" Background="#323232" CornerRadius="5">
@@ -24,11 +24,11 @@
 				<Border CornerRadius="5,5,0,0" Background="#282828" Height="40" PointerPressed="OnPointerPressed">
 					<Grid ColumnDefinitions="1*,1*">
 						<TextBlock Text="Sort Presets" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
-						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:SortPresetsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>
+						<Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:SortAtisStationsDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>
 					</Grid>
 				</Border>
 				<Grid ColumnDefinitions="1*,10,80" Margin="20">
-					<TreeDataGrid Grid.Column="0" CornerRadius="5" BorderBrush="#646464" BorderThickness="1" MaxHeight="200" Source="{Binding Source, DataType=vm:SortPresetsDialogViewModel, Mode=OneWay}" CanUserResizeColumns="False" CanUserSortColumns="False">
+					<TreeDataGrid Grid.Column="0" CornerRadius="5" BorderBrush="#646464" BorderThickness="1" MaxHeight="200" Source="{Binding Source, DataType=vm:SortAtisStationsDialogViewModel, Mode=OneWay}" CanUserResizeColumns="False" CanUserSortColumns="False">
 						<TreeDataGrid.Styles>
 							<Style Selector="TreeDataGrid /template/ Border#ColumnHeadersPresenterBorder">
 								<Setter Property="IsVisible" Value="False"/>
@@ -43,8 +43,8 @@
 					</TreeDataGrid>
 					<!--Up/Down Buttons-->
 					<StackPanel Grid.Column="2" Orientation="Vertical" Spacing="5">
-						<Button Theme="{StaticResource Dark}" Command="{Binding MovePresetUpCommand, DataType=vm:SortPresetsDialogViewModel}">Up</Button>
-						<Button Theme="{StaticResource Dark}" Command="{Binding MovePresetDownCommand, DataType=vm:SortPresetsDialogViewModel}">Down</Button>
+						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationUpCommand, DataType=vm:SortAtisStationsDialogViewModel}">Up</Button>
+						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationDownCommand, DataType=vm:SortAtisStationsDialogViewModel}">Down</Button>
 					</StackPanel>
 				</Grid>
 			</StackPanel>

--- a/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml
@@ -43,8 +43,8 @@
 					</TreeDataGrid>
 					<!--Up/Down Buttons-->
 					<StackPanel Grid.Column="2" Orientation="Vertical" Spacing="5">
-						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationUpCommand, DataType=vm:SortAtisStationsDialogViewModel}">Up</Button>
-						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationDownCommand, DataType=vm:SortAtisStationsDialogViewModel}">Down</Button>
+						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationUpCommand, DataType=vm:SortAtisStationsDialogViewModel}">Move Up</Button>
+						<Button Theme="{StaticResource Dark}" Command="{Binding MoveStationDownCommand, DataType=vm:SortAtisStationsDialogViewModel}">Move Down</Button>
 					</StackPanel>
 				</Grid>
 			</StackPanel>

--- a/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/SortAtisStationsDialog.axaml.cs
@@ -1,0 +1,49 @@
+// <copyright file="SortAtisStationsDialog.axaml.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using Avalonia.Input;
+using Avalonia.ReactiveUI;
+using Vatsim.Vatis.Ui.ViewModels;
+
+namespace Vatsim.Vatis.Ui.Dialogs;
+
+/// <summary>
+/// Represents a dialog for sorting ATIS stations.
+/// </summary>
+public partial class SortAtisStationsDialog : ReactiveWindow<SortAtisStationsDialogViewModel>, ICloseable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortAtisStationsDialog"/> class.
+    /// </summary>
+    /// <param name="viewModel">The view model associated with this dialog.</param>
+    public SortAtisStationsDialog(SortAtisStationsDialogViewModel viewModel)
+    {
+        InitializeComponent();
+        ViewModel = viewModel;
+        Closed += OnClosed;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortAtisStationsDialog"/> class.
+    /// </summary>
+    public SortAtisStationsDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        ViewModel?.Dispose();
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/IWindowFactory.cs
+++ b/vATIS.Desktop/Ui/IWindowFactory.cs
@@ -97,4 +97,10 @@ public interface IWindowFactory
     /// </summary>
     /// <returns>An instance of the <see cref="SortPresetsDialog"/> class.</returns>
     SortPresetsDialog CreateSortPresetsDialog();
+
+    /// <summary>
+    /// Creates and initializes a new instance of the <see cref="SortAtisStationsDialog"/> class.
+    /// </summary>
+    /// <returns>An instance of the <see cref="SortAtisStationsDialog"/> class.</returns>
+    SortAtisStationsDialog CreateSortAtisStationsDialog();
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -106,6 +106,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         _disposables.Add(RenameAtisCommand);
         _disposables.Add(CopyAtisCommand);
         _disposables.Add(ImportAtisStationCommand);
+        _disposables.Add(OpenSortAtisStationsDialogCommand);
 
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
         {

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -73,6 +73,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private string? _id;
     private string? _identifier;
     private string? _tabText;
+    private int _ordinal;
     private char _atisLetter;
     private bool _isAtisLetterInputMode;
     private string? _metarString;
@@ -136,6 +137,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         Id = station.Id;
         Identifier = station.Identifier;
+        Ordinal = station.Ordinal;
         _atisStation = station;
         _appConfig = appConfig;
         _atisBuilder = atisBuilder;
@@ -590,6 +592,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// Gets a value indicating the ATIS type.
     /// </summary>
     public AtisType AtisType => _atisStation.AtisType;
+
+    /// <summary>
+    /// Gets or sets a value indicating the station sort ordinal.
+    /// </summary>
+    public int Ordinal
+    {
+        get => _ordinal;
+        set => this.RaiseAndSetIfChanged(ref _ordinal, value);
+    }
 
     /// <summary>
     /// Disconnects the current network connection and updates the network connection status

--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -112,7 +112,7 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
             .Bind(out var sortedStations)
             .Subscribe(_ =>
             {
-                // Generate composite keys using Identifier + Ordinal
+                // Generate composite keys using Identifier + AtisType + Ordinal
                 var currentKeys = sortedStations.Select(s => $"{s.Identifier}_{s.AtisType}_{s.Ordinal}").ToList();
                 var keysChanged = !_previousKeys.SequenceEqual(currentKeys);
                 _previousKeys = currentKeys;

--- a/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
@@ -118,7 +118,7 @@ public class SortAtisStationsDialogViewModel : ReactiveViewModelBase, IDisposabl
 
     private void HandleMoveStationDown()
     {
-        if (Source.RowSelection?.SelectedIndex <= Source.Items.Count() - 1)
+        if (Source.RowSelection?.SelectedIndex < Source.Items.Count() - 1)
         {
             var definition = Source.RowSelection.SelectedItem;
             var oldIndex = Source.RowSelection.SelectedIndex.FirstOrDefault();

--- a/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
@@ -1,0 +1,135 @@
+// <copyright file="SortAtisStationsDialogViewModel.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Media;
+using ReactiveUI;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Ui.ViewModels;
+
+/// <summary>
+/// Represents the view model for the dialog used to sort ATIS stations.
+/// </summary>
+public class SortAtisStationsDialogViewModel : ReactiveViewModelBase, IDisposable
+{
+    private ObservableCollection<AtisStation> _stations = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortAtisStationsDialogViewModel"/> class.
+    /// </summary>
+    public SortAtisStationsDialogViewModel()
+    {
+        var textColumnLength = new GridLength(1, GridUnitType.Star);
+        Source = new FlatTreeDataGridSource<AtisStation>(AtisStations)
+        {
+            Columns =
+            {
+                new TextColumn<AtisStation, string>("", x => x.ToString(), width: textColumnLength,
+                    new TextColumnOptions<AtisStation> { TextWrapping = TextWrapping.Wrap })
+            }
+        };
+        Source.RowSelection!.SingleSelect = false;
+
+        var canMoveUp = this.WhenAnyValue(x => x.Source.RowSelection!.SelectedIndex)
+            .Select(x => x > 0);
+        var canMoveDown = this.WhenAnyValue(x => x.Source.RowSelection!.SelectedIndex)
+            .Select(x => x < AtisStations.Count - 1);
+
+        CloseWindowCommand = ReactiveCommand.Create<ICloseable>(HandleCloseWindow);
+        MoveStationUpCommand = ReactiveCommand.Create(HandleMoveStationUp, canMoveUp);
+        MoveStationDownCommand = ReactiveCommand.Create(HandleMoveStationDown, canMoveDown);
+    }
+
+    /// <summary>
+    /// Gets the command that closes the current window or dialog.
+    /// </summary>
+    /// <value>
+    /// A reactive command that takes an <see cref="ICloseable"/> instance as a parameter and performs the close operation.
+    /// </value>
+    public ReactiveCommand<ICloseable, Unit> CloseWindowCommand { get; }
+
+    /// <summary>
+    /// Gets the command that moves the selected station up in the list.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> MoveStationUpCommand { get; }
+
+    /// <summary>
+    /// Gets the command that moves the selected station down in the list.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> MoveStationDownCommand { get; }
+
+    /// <summary>
+    /// Gets or sets the collection of ATIS stations managed within the view model.
+    /// </summary>
+    public ObservableCollection<AtisStation> AtisStations
+    {
+        get => _stations;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _stations, value);
+            Source.Items = _stations.OrderBy(x => x.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Gets the data source for the tree data grid used for sorting ATIS stations.
+    /// </summary>
+    public FlatTreeDataGridSource<AtisStation> Source { get; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        CloseWindowCommand.Dispose();
+        MoveStationUpCommand.Dispose();
+        MoveStationDownCommand.Dispose();
+    }
+
+    private void HandleCloseWindow(ICloseable window)
+    {
+        window.Close();
+    }
+
+    private void HandleMoveStationUp()
+    {
+        if (Source.RowSelection?.SelectedIndex >= 1)
+        {
+            var definition = Source.RowSelection.SelectedItem;
+            var newIndex = Source.RowSelection.SelectedIndex.FirstOrDefault() - 1;
+            var oldIndex = Source.RowSelection.SelectedIndex.FirstOrDefault();
+            if (definition != null)
+            {
+                AtisStations.Move(oldIndex, newIndex);
+                definition.Ordinal = newIndex;
+                Source.Items = AtisStations.OrderBy(x => x.Ordinal).ToList();
+                Source.RowSelection.SelectedIndex = newIndex;
+            }
+        }
+    }
+
+    private void HandleMoveStationDown()
+    {
+        if (Source.RowSelection?.SelectedIndex <= Source.Items.Count() - 1)
+        {
+            var definition = Source.RowSelection.SelectedItem;
+            var oldIndex = Source.RowSelection.SelectedIndex.FirstOrDefault();
+            var newIndex = Source.RowSelection.SelectedIndex.FirstOrDefault() + 1;
+            if (definition != null)
+            {
+                AtisStations.Move(oldIndex, newIndex);
+                definition.Ordinal = newIndex;
+                Source.Items = AtisStations.OrderBy(x => x.Ordinal).ToList();
+                Source.RowSelection.SelectedIndex = newIndex;
+            }
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
@@ -109,7 +109,7 @@ public class SortAtisStationsDialogViewModel : ReactiveViewModelBase, IDisposabl
             if (definition != null)
             {
                 AtisStations.Move(oldIndex, newIndex);
-                definition.Ordinal = newIndex;
+                NormalizeOrdinals();
                 Source.Items = AtisStations.OrderBy(x => x.Ordinal).ToList();
                 Source.RowSelection.SelectedIndex = newIndex;
             }
@@ -126,10 +126,18 @@ public class SortAtisStationsDialogViewModel : ReactiveViewModelBase, IDisposabl
             if (definition != null)
             {
                 AtisStations.Move(oldIndex, newIndex);
-                definition.Ordinal = newIndex;
+                NormalizeOrdinals();
                 Source.Items = AtisStations.OrderBy(x => x.Ordinal).ToList();
                 Source.RowSelection.SelectedIndex = newIndex;
             }
+        }
+    }
+
+    private void NormalizeOrdinals()
+    {
+        for (var i = 0; i < AtisStations.Count; i++)
+        {
+            AtisStations[i].Ordinal = i;
         }
     }
 }

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
@@ -104,9 +104,10 @@
 							<views:SandboxView DataContext="{Binding SandboxViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
 					</TabControl>
-					<Grid ColumnDefinitions="30*,70*" Grid.Column="0" Grid.Row="1">
-						<Button Command="{Binding NewAtisStationDialogCommand, DataType=vm:AtisConfigurationWindowViewModel}" Grid.Column="0" Margin="0,0,5,0" Theme="{StaticResource Dark}" Height="28">New</Button>
-						<Button Grid.Column="1" Theme="{StaticResource Dark}" Height="28" Command="{Binding ImportAtisStationCommand, DataType=vm:AtisConfigurationWindowViewModel}">Import Existing</Button>
+					<Grid ColumnDefinitions="1*,1*,1*" Grid.Column="0" Grid.Row="1">
+						<Button Command="{Binding NewAtisStationDialogCommand, DataType=vm:AtisConfigurationWindowViewModel}" Grid.Column="0" Margin="0,0,5,0" Theme="{StaticResource Dark}" Height="28" HorizontalAlignment="Stretch">New</Button>
+                        <Button Grid.Column="1" Theme="{StaticResource Dark}" Height="28" Command="{Binding OpenSortAtisStationsDialogCommand, DataType=vm:AtisConfigurationWindowViewModel}" Margin="0,0,5,0" HorizontalAlignment="Stretch">Sort</Button>
+                        <Button Grid.Column="2" Theme="{StaticResource Dark}" Height="28" Command="{Binding ImportAtisStationCommand, DataType=vm:AtisConfigurationWindowViewModel}" HorizontalAlignment="Stretch">Import</Button>
 					</Grid>
 					<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="1" Spacing="5">
 						<Button Theme="{StaticResource Dark}" Height="28" Command="{Binding SaveAndCloseCommand, DataType=vm:AtisConfigurationWindowViewModel}" CommandParameter="{Binding ElementName=Window}">Save &amp; Close</Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new, interactive sorting dialog that allows users to reorder ATIS stations.
  - Enhanced the ATIS configuration window with a dedicated sorting button.
  - Implemented an auto-scroll behavior to ensure the selected station is always visible.
  - Improved the station ordering mechanism by utilizing an ordinal property.
  - Added event handling to keep station order updated across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->