### PR TITLE
Enhance the UI display of static and free-text airport conditions and NOTAMs

### DIFF
--- a/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml
@@ -65,12 +65,20 @@
 		<Grid ColumnDefinitions="50*,10,50*" RowDefinitions="*,*">
 			<StackPanel Grid.Column="0" Orientation="Vertical" Spacing="5">
 				<TextBlock Text="Text ATIS:"/>
-				<TextBox Text="{Binding SandboxTextAtis, DataType=vm:SandboxViewModel}" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" Height="110" Theme="{StaticResource DarkTextBox}" FontFamily="{StaticResource Monospace}"/>
+                <editor:TextEditor Height="110" Padding="4" Document="{Binding TextAtisTextDocument, DataType=vm:SandboxViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" IsReadOnly="True">
+                    <editor:TextEditor.Options>
+                        <editor:TextEditorOptions AllowScrollBelowDocument="False"/>
+                    </editor:TextEditor.Options>
+                </editor:TextEditor>
 			</StackPanel>
 			<Button Grid.Column="0" Grid.Row="1" Margin="0,10,0,0" HorizontalAlignment="Stretch" Theme="{StaticResource Dark}" Content="Refresh ATIS" Command="{Binding RefreshSandboxAtisCommand, DataType=vm:SandboxViewModel}"/>
 			<StackPanel Grid.Column="2" Grid.Row="0" Orientation="Vertical" Spacing="5">
 				<TextBlock Text="Voice ATIS:"/>
-				<TextBox Text="{Binding SandboxSpokenTextAtis, DataType=vm:SandboxViewModel}" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" Height="110" Theme="{StaticResource DarkTextBox}" FontFamily="{StaticResource Monospace}"/>
+                <editor:TextEditor Height="110" Padding="4" Document="{Binding VoiceAtisTextDocument, DataType=vm:SandboxViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" IsReadOnly="True">
+                    <editor:TextEditor.Options>
+                        <editor:TextEditorOptions AllowScrollBelowDocument="False"/>
+                    </editor:TextEditor.Options>
+                </editor:TextEditor>
 			</StackPanel>
 			<Button Grid.Row="1" Grid.Column="2" Margin="0,10,0,0" Theme="{StaticResource Dark}" Command="{Binding PlaySandboxAtisCommand, DataType=vm:SandboxViewModel}" Content="{Binding IsSandboxPlaybackActive, DataType=vm:SandboxViewModel, Converter={StaticResource ButtonLabelConverter}, FallbackValue=Listen}"/>
 		</Grid>

--- a/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
@@ -53,40 +53,71 @@ public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
         if (ViewModel == null)
             return;
 
-        NotamFreeText.TextArea.Caret.PositionChanged += (_, _) =>
-        {
-            if (ViewModel?.ReadOnlyNotams == null)
-                return;
+        NotamFreeText.TextChanged += (_, _) => NotamsCaretPosition();
+        NotamFreeText.TextArea.Caret.PositionChanged += (_, _) => NotamsCaretPosition();
+        NotamFreeText.TextArea.GotFocus += (_, _) => NotamsCaretPosition();
 
-            foreach (var segment in ViewModel.ReadOnlyNotams)
+        AirportConditions.TextChanged += (_, _) => AirportConditionsCaretPosition();
+        AirportConditions.TextArea.Caret.PositionChanged += (_, _) => AirportConditionsCaretPosition();
+        AirportConditions.TextArea.GotFocus += (_, _) => AirportConditionsCaretPosition();
+    }
+
+    private void NotamsCaretPosition()
+    {
+        if (ViewModel?.ReadOnlyNotams == null)
+            return;
+
+        if (ViewModel.SelectedStation == null)
+            return;
+
+        foreach (var segment in ViewModel.ReadOnlyNotams)
+        {
+            // If caret is within or at the start of a read-only segment
+            if (NotamFreeText.CaretOffset >= segment.StartOffset && NotamFreeText.CaretOffset <= segment.EndOffset)
             {
-                // If caret is within or at the start of a read-only segment
-                if (NotamFreeText.CaretOffset >= segment.StartOffset && NotamFreeText.CaretOffset <= segment.EndOffset)
+                if (ViewModel.SelectedStation.NotamsBeforeFreeText)
                 {
                     // Move caret to the end of the read-only segment
                     NotamFreeText.CaretOffset = segment.EndOffset;
-                    break;
                 }
+                else
+                {
+                    // Move caret to the beginning of the read-only segment
+                    NotamFreeText.CaretOffset = segment.StartOffset;
+                }
+
+                break;
             }
-        };
+        }
+    }
 
-        AirportConditions.TextArea.Caret.PositionChanged += (_, _) =>
+    private void AirportConditionsCaretPosition()
+    {
+        if (ViewModel?.ReadOnlyAirportConditions == null)
+            return;
+
+        if (ViewModel.SelectedStation == null)
+            return;
+
+        foreach (var segment in ViewModel.ReadOnlyAirportConditions)
         {
-            if (ViewModel?.ReadOnlyAirportConditions == null)
-                return;
-
-            foreach (var segment in ViewModel.ReadOnlyAirportConditions)
+            // If caret is within or at the start of a read-only segment
+            if (AirportConditions.CaretOffset >= segment.StartOffset && AirportConditions.CaretOffset <= segment.EndOffset)
             {
-                // If caret is within or at the start of a read-only segment
-                if (AirportConditions.CaretOffset >= segment.StartOffset &&
-                    AirportConditions.CaretOffset <= segment.EndOffset)
+                if (ViewModel.SelectedStation.AirportConditionsBeforeFreeText)
                 {
                     // Move caret to the end of the read-only segment
                     AirportConditions.CaretOffset = segment.EndOffset;
-                    break;
                 }
+                else
+                {
+                    // Move caret to the beginning of the read-only segment
+                    AirportConditions.CaretOffset = segment.StartOffset;
+                }
+
+                break;
             }
-        };
+        }
     }
 
     private void AirportConditions_OnTextChanged(object? sender, EventArgs e)

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml
@@ -62,7 +62,7 @@
 					<Button Grid.Column="0" Theme="{StaticResource HyperlinkButton}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5" Command="{Binding OpenStaticNotamsDialogCommand, DataType=vm:AtisStationViewModel}">NOTAMS</Button>
 					<Button Grid.Column="1" Theme="{StaticResource HyperlinkButtonSave}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5"  HorizontalAlignment="Right" IsVisible="{Binding HasUnsavedNotams, DataType=vm:AtisStationViewModel, FallbackValue=False}" Command="{Binding SaveNotamsText, DataType=vm:AtisStationViewModel}">★SAVE CHANGES★</Button>
 				</Grid>
-				<editor:TextEditor Name="NotamFreeText" Grid.Row="1" Grid.Column="2" Document="{Binding NotamsTextDocument, DataType=vm:AtisStationViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" Padding="4" TextChanged="NotamFreeText_OnTextChanged">
+				<editor:TextEditor Name="NotamText" Grid.Row="1" Grid.Column="2" Document="{Binding NotamsTextDocument, DataType=vm:AtisStationViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" Padding="4" TextChanged="NotamText_OnTextChanged">
 					<Interaction.Behaviors>
 						<behaviors:TextEditorUpperCaseBehavior/>
 						<behaviors:TextEditorCompletionBehavior CompletionData="{Binding ContractionCompletionData, DataType=vm:AtisStationViewModel}"/>

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
@@ -637,7 +637,7 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         // Reset offset
         _notamFreeTextOffset = 0;
 
-        var staticDefinitionsString = string.Join(". ", staticDefinitions) + ". ";
+        var staticDefinitionsString = string.Join(". ", staticDefinitions.Select(s => s.Text.TrimEnd('.'))) + ". ";
 
         // Insert static definitions before free-text
         if (SelectedStation.NotamsBeforeFreeText)
@@ -732,7 +732,7 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         // Reset offset
         _airportConditionsFreeTextOffset = 0;
 
-        var staticDefinitionsString = string.Join(". ", staticDefinitions) + ". ";
+        var staticDefinitionsString = string.Join(". ", staticDefinitions.Select(s => s.Text.TrimEnd('.'))) + ". ";
 
         // Insert static definitions before free-text
         if (SelectedStation.AirportConditionsBeforeFreeText)

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -54,7 +54,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private readonly IAppConfig _appConfig;
     private readonly IProfileRepository _profileRepository;
     private readonly IAtisBuilder _atisBuilder;
-    private readonly AtisStation _atisStation;
     private readonly IWindowFactory _windowFactory;
     private readonly INetworkConnection? _networkConnection;
     private readonly IVoiceServerConnection? _voiceServerConnection;
@@ -140,7 +139,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         Id = station.Id;
         Identifier = station.Identifier;
         Ordinal = station.Ordinal;
-        _atisStation = station;
+        AtisStation = station;
         _appConfig = appConfig;
         _atisBuilder = atisBuilder;
         _windowFactory = windowFactory;
@@ -152,7 +151,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         _atisStationAirport = navDataRepository.GetAirport(station.Identifier) ??
                               throw new ApplicationException($"{station.Identifier} not found in airport navdata.");
 
-        _atisLetter = _atisStation.CodeRange.Low;
+        _atisLetter = AtisStation.CodeRange.Low;
 
         ReadOnlyAirportConditions = new TextSegmentCollection<TextSegment>(AirportConditionsTextDocument);
         ReadOnlyNotams = new TextSegmentCollection<TextSegment>(NotamsTextDocument);
@@ -205,7 +204,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
         LoadContractionData();
 
-        _networkConnection = connectionFactory.CreateConnection(_atisStation);
+        _networkConnection = connectionFactory.CreateConnection(AtisStation);
         _networkConnection.NetworkConnectionFailed += OnNetworkConnectionFailed;
         _networkConnection.NetworkErrorReceived += OnNetworkErrorReceived;
         _networkConnection.NetworkConnected += OnNetworkConnected;
@@ -215,24 +214,24 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         _networkConnection.KillRequestReceived += OnKillRequestedReceived;
         _voiceServerConnection = voiceServerConnectionFactory.CreateVoiceServerConnection();
 
-        UseTexToSpeech = !_atisStation.AtisVoice.UseTextToSpeech;
+        UseTexToSpeech = !AtisStation.AtisVoice.UseTextToSpeech;
         _disposables.Add(EventBus.Instance.Subscribe<AtisVoiceTypeChanged>(evt =>
         {
-            if (evt.Id == _atisStation.Id)
+            if (evt.Id == AtisStation.Id)
             {
                 UseTexToSpeech = !evt.UseTextToSpeech;
             }
         }));
         _disposables.Add(EventBus.Instance.Subscribe<StationPresetsChanged>(evt =>
         {
-            if (evt.Id == _atisStation.Id)
+            if (evt.Id == AtisStation.Id)
             {
-                AtisPresetList = new ObservableCollection<AtisPreset>(_atisStation.Presets.OrderBy(x => x.Ordinal));
+                AtisPresetList = new ObservableCollection<AtisPreset>(AtisStation.Presets.OrderBy(x => x.Ordinal));
             }
         }));
         _disposables.Add(EventBus.Instance.Subscribe<ContractionsUpdated>(evt =>
         {
-            if (evt.StationId == _atisStation.Id)
+            if (evt.StationId == AtisStation.Id)
             {
                 LoadContractionData();
             }
@@ -271,13 +270,13 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }));
         _disposables.Add(EventBus.Instance.Subscribe<AtisHubExpiredAtisReceived>(sync =>
         {
-            if (sync.Dto.StationId == _atisStation.Identifier &&
-                sync.Dto.AtisType == _atisStation.AtisType &&
+            if (sync.Dto.StationId == AtisStation.Identifier &&
+                sync.Dto.AtisType == AtisStation.AtisType &&
                 NetworkConnectionStatus == NetworkConnectionStatus.Observer)
             {
                 Dispatcher.UIThread.Post(() =>
                 {
-                    AtisLetter = _atisStation.CodeRange.Low;
+                    AtisLetter = AtisStation.CodeRange.Low;
                     Wind = null;
                     Altimeter = null;
                     Metar = null;
@@ -298,7 +297,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }));
         _disposables.Add(EventBus.Instance.Subscribe<HubConnected>(_ =>
         {
-            _atisHubConnection.SubscribeToAtis(new SubscribeDto(_atisStation.Identifier, _atisStation.AtisType));
+            _atisHubConnection.SubscribeToAtis(new SubscribeDto(AtisStation.Identifier, AtisStation.AtisType));
         }));
         _disposables.Add(EventBus.Instance.Subscribe<SessionEnded>(_ =>
         {
@@ -378,6 +377,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     public ReactiveCommand<char, Unit> SetAtisLetterCommand { get; }
 
     /// <summary>
+    /// Gets the ATIS station.
+    /// </summary>
+    public AtisStation AtisStation { get; }
+
+    /// <summary>
     /// Gets the unique identifier for the ATIS station.
     /// </summary>
     public string? Id
@@ -416,7 +420,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets the range of valid ATIS code letters associated with the ATIS station.
     /// </summary>
-    public CodeRangeMeta CodeRange => _atisStation.CodeRange;
+    public CodeRangeMeta CodeRange => AtisStation.CodeRange;
 
     /// <summary>
     /// Gets or sets a value indicating whether the ATIS letter input mode is active.
@@ -593,7 +597,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets a value indicating the ATIS type.
     /// </summary>
-    public AtisType AtisType => _atisStation.AtisType;
+    public AtisType AtisType => AtisStation.AtisType;
 
     /// <summary>
     /// Gets or sets a value indicating the station sort ordinal.
@@ -650,7 +654,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void HandleSetAtisLetter(char letter)
     {
-        if (letter < _atisStation.CodeRange.Low || letter > _atisStation.CodeRange.High)
+        if (letter < AtisStation.CodeRange.Low || letter > AtisStation.CodeRange.High)
             return;
         AtisLetter = letter;
     }
@@ -695,7 +699,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         ContractionCompletionData.Clear();
 
-        foreach (var contraction in _atisStation.Contractions.ToList())
+        foreach (var contraction in AtisStation.Contractions.ToList())
         {
             if (contraction is { VariableName: not null, Voice: not null })
                 ContractionCompletionData.Add(new AutoCompletionData(contraction.VariableName, contraction.Voice));
@@ -714,21 +718,21 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         dlg.Topmost = lifetime.MainWindow.Topmost;
         if (dlg.DataContext is StaticNotamsDialogViewModel viewModel)
         {
-            viewModel.Definitions = new ObservableCollection<StaticDefinition>(_atisStation.NotamDefinitions);
+            viewModel.Definitions = new ObservableCollection<StaticDefinition>(AtisStation.NotamDefinitions);
             viewModel.ContractionCompletionData = ContractionCompletionData;
-            viewModel.IncludeBeforeFreeText = _atisStation.NotamsBeforeFreeText;
+            viewModel.IncludeBeforeFreeText = AtisStation.NotamsBeforeFreeText;
 
             viewModel.WhenAnyValue(x => x.IncludeBeforeFreeText).Subscribe(val =>
             {
-                _atisStation.NotamsBeforeFreeText = val;
+                AtisStation.NotamsBeforeFreeText = val;
                 if (_sessionManager.CurrentProfile != null)
                     _profileRepository.Save(_sessionManager.CurrentProfile);
             });
 
             viewModel.Definitions.ToObservableChangeSet().AutoRefresh(x => x.Enabled).Bind(out var changes).Subscribe(_ =>
             {
-                _atisStation.NotamDefinitions.Clear();
-                _atisStation.NotamDefinitions.AddRange(changes);
+                AtisStation.NotamDefinitions.Clear();
+                AtisStation.NotamDefinitions.AddRange(changes);
                 if (_sessionManager.CurrentProfile != null)
                     _profileRepository.Save(_sessionManager.CurrentProfile);
             });
@@ -736,11 +740,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             viewModel.Definitions.CollectionChanged += (_, _) =>
             {
                 var idx = 0;
-                _atisStation.NotamDefinitions.Clear();
+                AtisStation.NotamDefinitions.Clear();
                 foreach (var item in viewModel.Definitions)
                 {
                     item.Ordinal = ++idx;
-                    _atisStation.NotamDefinitions.Add(item);
+                    AtisStation.NotamDefinitions.Add(item);
                 }
 
                 if (_sessionManager.CurrentProfile != null)
@@ -766,21 +770,21 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         dlg.Topmost = lifetime.MainWindow.Topmost;
         if (dlg.DataContext is StaticAirportConditionsDialogViewModel viewModel)
         {
-            viewModel.Definitions = new ObservableCollection<StaticDefinition>(_atisStation.AirportConditionDefinitions);
+            viewModel.Definitions = new ObservableCollection<StaticDefinition>(AtisStation.AirportConditionDefinitions);
             viewModel.ContractionCompletionData = ContractionCompletionData;
-            viewModel.IncludeBeforeFreeText = _atisStation.AirportConditionsBeforeFreeText;
+            viewModel.IncludeBeforeFreeText = AtisStation.AirportConditionsBeforeFreeText;
 
             viewModel.WhenAnyValue(x => x.IncludeBeforeFreeText).Subscribe(val =>
             {
-                _atisStation.AirportConditionsBeforeFreeText = val;
+                AtisStation.AirportConditionsBeforeFreeText = val;
                 if (_sessionManager.CurrentProfile != null)
                     _profileRepository.Save(_sessionManager.CurrentProfile);
             });
 
             viewModel.Definitions.ToObservableChangeSet().AutoRefresh(x => x.Enabled).Bind(out var changes).Subscribe(_ =>
             {
-                _atisStation.AirportConditionDefinitions.Clear();
-                _atisStation.AirportConditionDefinitions.AddRange(changes);
+                AtisStation.AirportConditionDefinitions.Clear();
+                AtisStation.AirportConditionDefinitions.AddRange(changes);
                 if (_sessionManager.CurrentProfile != null)
                     _profileRepository.Save(_sessionManager.CurrentProfile);
             });
@@ -788,11 +792,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             viewModel.Definitions.CollectionChanged += (_, _) =>
             {
                 var idx = 0;
-                _atisStation.AirportConditionDefinitions.Clear();
+                AtisStation.AirportConditionDefinitions.Clear();
                 foreach (var item in viewModel.Definitions)
                 {
                     item.Ordinal = ++idx;
-                    _atisStation.AirportConditionDefinitions.Add(item);
+                    AtisStation.AirportConditionDefinitions.Add(item);
                 }
 
                 if (_sessionManager.CurrentProfile != null)
@@ -843,7 +847,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 var window = _windowFactory.CreateVoiceRecordAtisDialog();
                 if (window.DataContext is VoiceRecordAtisDialogViewModel vm)
                 {
-                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
+                    var textAtis = await _atisBuilder.BuildTextAtis(AtisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
                         _cancellationToken.Token);
 
                     vm.AtisScript = textAtis;
@@ -853,15 +857,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     {
                         await Task.Run(async () =>
                         {
-                            _atisStation.TextAtis = textAtis;
-                            _atisStation.AtisLetter = AtisLetter;
+                            AtisStation.TextAtis = textAtis;
+                            AtisStation.AtisLetter = AtisLetter;
 
                             await PublishAtisToHub();
                             _networkConnection.SendSubscriberNotification(AtisLetter);
-                            await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter,
+                            await _atisBuilder.UpdateIds(AtisStation, SelectedAtisPreset, AtisLetter,
                                 _cancellationToken.Token);
 
-                            var dto = AtisBotUtils.AddBotRequest(vm.AudioBuffer, _atisStation.Frequency,
+                            var dto = AtisBotUtils.AddBotRequest(vm.AudioBuffer, AtisStation.Frequency,
                                 _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
                             await _voiceServerConnection.AddOrUpdateBot(_networkConnection.Callsign, dto,
                                 _cancellationToken.Token);
@@ -1164,7 +1168,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 throw;
             }
 
-            if (_atisStation.AtisVoice.UseTextToSpeech)
+            if (AtisStation.AtisVoice.UseTextToSpeech)
             {
                 try
                 {
@@ -1173,11 +1177,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     _cancellationToken.Dispose();
                     _cancellationToken = new CancellationTokenSource();
 
-                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, e.Metar,
+                    var textAtis = await _atisBuilder.BuildTextAtis(AtisStation, SelectedAtisPreset, AtisLetter, e.Metar,
                         _cancellationToken.Token);
 
-                    _atisStation.TextAtis = textAtis?.ToUpperInvariant();
-                    _atisStation.AtisLetter = AtisLetter;
+                    AtisStation.TextAtis = textAtis?.ToUpperInvariant();
+                    AtisStation.AtisLetter = AtisLetter;
 
                     await PublishAtisToWebsocket();
                     await PublishAtisToHub();
@@ -1189,16 +1193,16 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                         _networkConnection?.SendSubscriberNotification(AtisLetter);
                     }
 
-                    await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
+                    await _atisBuilder.UpdateIds(AtisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
 
-                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(AtisStation, SelectedAtisPreset, AtisLetter,
                         e.Metar, _cancellationToken.Token);
 
                     if (voiceAtis.AudioBytes != null && _networkConnection != null)
                     {
                         await Task.Run(async () =>
                         {
-                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, AtisStation.Frequency,
                                 _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
                             await _voiceServerConnection.AddOrUpdateBot(_networkConnection.Callsign, dto,
                                 _cancellationToken.Token);
@@ -1253,13 +1257,13 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         await _websocketService.SendAtisMessage(session, new AtisMessage.AtisMessageValue
         {
-            Station = _atisStation.Identifier,
-            AtisType = _atisStation.AtisType,
+            Station = AtisStation.Identifier,
+            AtisType = AtisStation.AtisType,
             AtisLetter = AtisLetter,
             Metar = Metar?.Trim(),
             Wind = Wind?.Trim(),
             Altimeter = Altimeter?.Trim(),
-            TextAtis = _atisStation.TextAtis,
+            TextAtis = AtisStation.TextAtis,
             IsNewAtis = IsNewAtis,
             NetworkConnectionStatus = NetworkConnectionStatus,
             Pressure = _decodedMetar?.Pressure?.Value ?? null,
@@ -1302,7 +1306,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             var airportConditions = await Dispatcher.UIThread.InvokeAsync(() => AirportConditionsTextDocument?.Text);
             var notams = await Dispatcher.UIThread.InvokeAsync(() => NotamsTextDocument?.Text);
 
-            await _atisHubConnection.PublishAtis(new AtisHubDto(_atisStation.Identifier, _atisStation.AtisType,
+            await _atisHubConnection.PublishAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
                 AtisLetter, Metar?.Trim(), Wind?.Trim(), Altimeter?.Trim(), airportConditions, notams));
         }
         catch (Exception ex)
@@ -1338,31 +1342,31 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 if (_decodedMetar == null)
                     return;
 
-                var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
+                var textAtis = await _atisBuilder.BuildTextAtis(AtisStation, SelectedAtisPreset, AtisLetter, _decodedMetar,
                     _cancellationToken.Token);
 
-                _atisStation.TextAtis = textAtis?.ToUpperInvariant();
-                _atisStation.AtisLetter = AtisLetter;
+                AtisStation.TextAtis = textAtis?.ToUpperInvariant();
+                AtisStation.AtisLetter = AtisLetter;
 
                 await PublishAtisToHub();
                 await PublishAtisToWebsocket();
-                await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
+                await _atisBuilder.UpdateIds(AtisStation, SelectedAtisPreset, AtisLetter, _cancellationToken.Token);
 
-                if (_atisStation.AtisVoice.UseTextToSpeech)
+                if (AtisStation.AtisVoice.UseTextToSpeech)
                 {
                     // Cancel previous request
                     await _cancellationToken.CancelAsync();
                     _cancellationToken.Dispose();
                     _cancellationToken = new CancellationTokenSource();
 
-                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(AtisStation, SelectedAtisPreset, AtisLetter,
                         _decodedMetar, _cancellationToken.Token);
 
                     if (voiceAtis.AudioBytes != null)
                     {
                         await Task.Run(async () =>
                         {
-                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                            var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, AtisStation.Frequency,
                                 _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
                             await _voiceServerConnection.AddOrUpdateBot(_networkConnection.Callsign, dto,
                                 _cancellationToken.Token);
@@ -1398,7 +1402,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         ReadOnlyNotams.Clear();
 
         // Retrieve and sort enabled static NOTAM definitions by their ordinal value.
-        var staticDefinitions = _atisStation.NotamDefinitions
+        var staticDefinitions = AtisStation.NotamDefinitions
             .Where(x => x.Enabled)
             .OrderBy(x => x.Ordinal)
             .ToList();
@@ -1461,7 +1465,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             return;
 
         // Retrieve and sort enabled static airport conditions by their ordinal value.
-        var staticDefinitions = _atisStation.AirportConditionDefinitions
+        var staticDefinitions = AtisStation.AirportConditionDefinitions
             .Where(x => x.Enabled)
             .OrderBy(x => x.Ordinal)
             .ToList();
@@ -1485,7 +1489,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         var staticDefinitionsString = string.Join(". ", staticDefinitions) + ". ";
 
         // Insert static definitions before free-text
-        if (_atisStation.AirportConditionsBeforeFreeText)
+        if (AtisStation.AirportConditionsBeforeFreeText)
         {
             if (staticDefinitions.Count > 0)
             {
@@ -1559,7 +1563,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             // connected or doesn't support text to speech.
             await PublishAtisToWebsocket();
 
-            if (!_atisStation.AtisVoice.UseTextToSpeech)
+            if (!AtisStation.AtisVoice.UseTextToSpeech)
                 return;
 
             if (NetworkConnectionStatus != NetworkConnectionStatus.Connected)
@@ -1583,23 +1587,23 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 try
                 {
-                    var textAtis = await _atisBuilder.BuildTextAtis(_atisStation, SelectedAtisPreset, atisLetter,
+                    var textAtis = await _atisBuilder.BuildTextAtis(AtisStation, SelectedAtisPreset, atisLetter,
                         _decodedMetar, _cancellationToken.Token);
 
-                    _atisStation.TextAtis = textAtis?.ToUpperInvariant();
-                    _atisStation.AtisLetter = AtisLetter;
+                    AtisStation.TextAtis = textAtis?.ToUpperInvariant();
+                    AtisStation.AtisLetter = AtisLetter;
 
                     await PublishAtisToHub();
                     _networkConnection?.SendSubscriberNotification(AtisLetter);
-                    await _atisBuilder.UpdateIds(_atisStation, SelectedAtisPreset, AtisLetter,
+                    await _atisBuilder.UpdateIds(AtisStation, SelectedAtisPreset, AtisLetter,
                         _cancellationToken.Token);
 
-                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(_atisStation, SelectedAtisPreset, AtisLetter,
+                    var voiceAtis = await _atisBuilder.BuildVoiceAtis(AtisStation, SelectedAtisPreset, AtisLetter,
                         _decodedMetar, _cancellationToken.Token);
 
                     if (voiceAtis.AudioBytes != null && _networkConnection != null)
                     {
-                        var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, _atisStation.Frequency,
+                        var dto = AtisBotUtils.AddBotRequest(voiceAtis.AudioBytes, AtisStation.Frequency,
                             _atisStationAirport.Latitude, _atisStationAirport.Longitude, 100);
                         await _voiceServerConnection.AddOrUpdateBot(_networkConnection.Callsign, dto,
                             _cancellationToken.Token);
@@ -1641,7 +1645,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             // must match to acknowledge the update.
             // If a specific station isn't specified then the request is for all stations.
             if (!string.IsNullOrEmpty(e.Station) &&
-                (e.Station != _atisStation.Identifier || e.AtisType != _atisStation.AtisType))
+                (e.Station != AtisStation.Identifier || e.AtisType != AtisStation.AtisType))
             {
                 return;
             }
@@ -1660,7 +1664,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         // must match to acknowledge the update.
         // If a specific station isn't specified then the request is for all stations.
         if (!string.IsNullOrEmpty(e.Station) &&
-            (e.Station != _atisStation.Identifier || e.AtisType != _atisStation.AtisType))
+            (e.Station != AtisStation.Identifier || e.AtisType != AtisStation.AtisType))
         {
             return;
         }
@@ -1685,14 +1689,14 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }
 
         AtisLetter++;
-        if (AtisLetter > _atisStation.CodeRange.High)
-            AtisLetter = _atisStation.CodeRange.Low;
+        if (AtisLetter > AtisStation.CodeRange.High)
+            AtisLetter = AtisStation.CodeRange.Low;
     }
 
     private void DecrementAtisLetter()
     {
         AtisLetter--;
-        if (AtisLetter < _atisStation.CodeRange.Low)
-            AtisLetter = _atisStation.CodeRange.High;
+        if (AtisLetter < AtisStation.CodeRange.Low)
+            AtisLetter = AtisStation.CodeRange.High;
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1435,7 +1435,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         NotamsTextDocument.Text = "";
         _notamFreeTextOffset = 0;
 
-        var staticDefinitionsString = string.Join(". ", staticDefinitions) + ". ";
+        var staticDefinitionsString = string.Join(". ", staticDefinitions.Select(s => s.Text.TrimEnd('.'))) + ". ";
 
         // Insert static definitions before free-text
         if (AtisStation.NotamsBeforeFreeText)
@@ -1522,7 +1522,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         AirportConditionsTextDocument.Text = "";
         _airportConditionsFreeTextOffset = 0;
 
-        var staticDefinitionsString = string.Join(". ", staticDefinitions) + ". ";
+        var staticDefinitionsString = string.Join(". ", staticDefinitions.Select(s => s.Text.TrimEnd('.'))) + ". ";
 
         // Insert static definitions before free-text
         if (AtisStation.AirportConditionsBeforeFreeText)

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1481,6 +1481,10 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     : AirportConditionsTextDocument.Text[readonlySegment.Length..];
             }
         }
+        else
+        {
+            _previousFreeTextAirportConditions = "";
+        }
 
         ReadOnlyAirportConditions.Clear();
         AirportConditionsTextDocument.Text = "";

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1457,7 +1457,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             // Insert free-text after static definitions
             if (!string.IsNullOrEmpty(_previousFreeTextNotams))
             {
-                NotamsTextDocument.Insert(_notamFreeTextOffset, _previousFreeTextNotams.TrimEnd());
+                NotamsTextDocument.Insert(_notamFreeTextOffset, _previousFreeTextNotams.Trim());
             }
             else if (!string.IsNullOrEmpty(SelectedAtisPreset.Notams))
             {
@@ -1468,13 +1468,13 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             if (!string.IsNullOrEmpty(_previousFreeTextNotams))
             {
-                NotamsTextDocument.Insert(0, _previousFreeTextNotams + " ");
-                _notamFreeTextOffset = _previousFreeTextNotams.Length + 1;
+                NotamsTextDocument.Insert(0, _previousFreeTextNotams.Trim() + " ");
+                _notamFreeTextOffset = _previousFreeTextNotams.Trim().Length + 1;
             }
             else if (!string.IsNullOrEmpty(SelectedAtisPreset.Notams))
             {
-                NotamsTextDocument.Insert(0, SelectedAtisPreset.Notams + " ");
-                _notamFreeTextOffset = SelectedAtisPreset.Notams.Length + 1;
+                NotamsTextDocument.Insert(0, SelectedAtisPreset.Notams.Trim() + " ");
+                _notamFreeTextOffset = SelectedAtisPreset.Notams.Trim().Length + 1;
             }
 
             // Insert static definitions after free-text
@@ -1544,25 +1544,24 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             // Insert free-text after static definitions
             if (!string.IsNullOrEmpty(_previousFreeTextAirportConditions))
             {
-                AirportConditionsTextDocument.Insert(_airportConditionsFreeTextOffset, _previousFreeTextAirportConditions.TrimEnd());
+                AirportConditionsTextDocument.Insert(_airportConditionsFreeTextOffset, _previousFreeTextAirportConditions.Trim());
             }
             else if (!string.IsNullOrEmpty(SelectedAtisPreset.AirportConditions))
             {
-                AirportConditionsTextDocument.Insert(_airportConditionsFreeTextOffset,
-                    SelectedAtisPreset.AirportConditions);
+                AirportConditionsTextDocument.Insert(_airportConditionsFreeTextOffset, SelectedAtisPreset.AirportConditions);
             }
         }
         else
         {
             if (!string.IsNullOrEmpty(_previousFreeTextAirportConditions))
             {
-                AirportConditionsTextDocument.Insert(0, _previousFreeTextAirportConditions + " ");
-                _airportConditionsFreeTextOffset = _previousFreeTextAirportConditions.Length + 1;
+                AirportConditionsTextDocument.Insert(0, _previousFreeTextAirportConditions.Trim() + " ");
+                _airportConditionsFreeTextOffset = _previousFreeTextAirportConditions.Trim().Length + 1;
             }
             else if (!string.IsNullOrEmpty(SelectedAtisPreset.AirportConditions))
             {
-                AirportConditionsTextDocument.Insert(0, SelectedAtisPreset.AirportConditions + " ");
-                _airportConditionsFreeTextOffset = SelectedAtisPreset.AirportConditions.Length + 1;
+                AirportConditionsTextDocument.Insert(0, SelectedAtisPreset.AirportConditions.Trim() + " ");
+                _airportConditionsFreeTextOffset = SelectedAtisPreset.AirportConditions.Trim().Length + 1;
             }
 
             // Insert static definitions after free-text


### PR DESCRIPTION
The free text is now correctly placed either before or after the static definitions (blue text), based on the state of the "Include before free-form..." option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized text input fields for NOTAM and airport conditions to enhance consistency and improve user editing experience.
	- Streamlined handling of station details for a more uniform display across the application.
	- Enhanced caret position management for text inputs, ensuring contextual awareness based on selected station properties.
	- Improved handling of user-entered free text for NOTAMs and airport conditions when switching presets.
	- Upgraded text editing capabilities by replacing `TextBox` elements with `TextEditor` controls for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->