### PR TITLE
Use boolean instead of argument for triggering release notes after update

### DIFF
--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -184,7 +184,7 @@ public class App : Application
                 await UpdateAvailableVoicesAsync();
 
                 // Show release notes of new version
-                if (arguments.TryGetValue("--isUpdated", out _))
+                if (Program.IsUpdated)
                 {
                     try
                     {

--- a/vATIS.Desktop/Program.cs
+++ b/vATIS.Desktop/Program.cs
@@ -18,6 +18,11 @@ namespace Vatsim.Vatis;
 internal static class Program
 {
     /// <summary>
+    /// Gets a value indicating whether the application has been updated and the release notes should be displayed.
+    /// </summary>
+    public static bool IsUpdated { get; private set; }
+
+    /// <summary>
     /// Main entry point for the application.
     /// </summary>
     /// <param name="args">The command line arguments.</param>
@@ -27,7 +32,7 @@ internal static class Program
         try
         {
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
-            VelopackApp.Build().Run();
+            VelopackApp.Build().WithRestarted(_ => IsUpdated = true).Run();
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, Avalonia.Controls.ShutdownMode.OnExplicitShutdown);
         }
         catch (Exception ex)

--- a/vATIS.Desktop/Updates/ClientUpdater.cs
+++ b/vATIS.Desktop/Updates/ClientUpdater.cs
@@ -65,8 +65,7 @@ public class ClientUpdater : IClientUpdater
 
         if (_updateInfo == null) return false;
         await _updateManager.DownloadUpdatesAsync(_updateInfo, ReportProgress);
-        await _updateManager.WaitExitThenApplyUpdatesAsync(_updateInfo, silent: true,
-            restartArgs: ["--isUpdated"]);
+        await _updateManager.WaitExitThenApplyUpdatesAsync(_updateInfo, silent: true);
 
         return true;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the update experience by ensuring release notes are consistently shown when a new version is launched.
  
- **Chores**
  - Streamlined the update process by simplifying how update status is determined and removing legacy restart arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->