### PR TITLE
Add option to suppress release notes window

### DIFF
--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -189,7 +189,7 @@ public class App : Application
                 await UpdateAvailableVoicesAsync();
 
                 // Show release notes of new version
-                if (Program.IsUpdated)
+                if (Program.IsUpdated && !appConfig.SuppressReleaseNotes)
                 {
                     try
                     {
@@ -202,7 +202,11 @@ public class App : Application
                             if (releaseNotes.ViewModel != null)
                             {
                                 releaseNotes.ViewModel.ReleaseNotes = currentRelease.NotesMarkdown;
-                                await releaseNotes.ShowDialog(_startupWindow);
+                                if (await releaseNotes.ShowDialog<DialogResult>(_startupWindow) == DialogResult.Ok)
+                                {
+                                    appConfig.SuppressReleaseNotes = releaseNotes.ViewModel.SuppressReleaseNotes;
+                                    appConfig.SaveConfig();
+                                }
                             }
                         }
                     }

--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -62,6 +62,9 @@ public class AppConfig : IAppConfig
     public bool AutoFetchAtisLetter { get; set; }
 
     /// <inheritdoc />
+    public bool SuppressReleaseNotes { get; set; }
+
+    /// <inheritdoc />
     [JsonIgnore]
     public string PasswordDecrypted
     {
@@ -101,6 +104,7 @@ public class AppConfig : IAppConfig
             MicrophoneDevice = config.MicrophoneDevice;
             PlaybackDevice = config.PlaybackDevice;
             AutoFetchAtisLetter = config.AutoFetchAtisLetter;
+            SuppressReleaseNotes = config.SuppressReleaseNotes;
         }
 
         SaveConfig();

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -93,6 +93,11 @@ public interface IAppConfig
     bool AutoFetchAtisLetter { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to suppress the release notes window after updating.
+    /// </summary>
+    bool SuppressReleaseNotes { get; set; }
+
+    /// <summary>
     /// Loads the configuration settings for the application.
     /// </summary>
     void LoadConfig();

--- a/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml
@@ -5,32 +5,56 @@
         xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia"
         xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
         xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d"
         x:Class="Vatsim.Vatis.Ui.Dialogs.ReleaseNotesDialog"
+        x:Name="Window"
         Title="Release Notes"
-        Width="600" Height="500"
+        Width="700" Height="475"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         ShowInTaskbar="False"
         SystemDecorations="None"
         TransparencyLevelHint="Transparent"
         Background="Transparent">
-    <Border BorderBrush="#646464" BorderThickness="1" Background="#1E1E1E" CornerRadius="5">
-        <Grid RowDefinitions="*,10,Auto" Margin="15">
-            <mdxaml:MarkdownScrollViewer Grid.Row="0" Margin="0 -10 0 0" Markdown="{Binding ReleaseNotes, DataType=vm:ReleaseNotesDialogViewModel}">
-                <mdxaml:MarkdownScrollViewer.Styles>
-                    <Style Selector="ctxt|CTextBlock.Heading1">
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="FontSize" Value="28"/>
-                        <Setter Property="HorizontalAlignment" Value="Center"/>
-                    </Style>
-                    <Style Selector=".List ctxt|CTextBlock">
-                        <Setter Property="FontSize" Value="18"/>
-                    </Style>
-                </mdxaml:MarkdownScrollViewer.Styles>
-            </mdxaml:MarkdownScrollViewer>
-            <Button Grid.Row="2" Theme="{StaticResource Dark}" FontSize="24" HorizontalAlignment="Stretch" Content="CLOSE" Click="CloseWindow"/>
+    <Border BorderBrush="#646464" BorderThickness="1" Background="#1E1E1E" CornerRadius="5" ClipToBounds="True">
+        <Grid RowDefinitions="40,*,Auto">
+            <Border CornerRadius="5,5,0,0" Background="#1E1E1E" Height="40" Grid.Row="0">
+                <Grid ColumnDefinitions="1*,1*">
+                    <TextBlock Text="Release Notes" Padding="5" Margin="5,0,0,0" VerticalAlignment="Center" Foreground="#F0F0F0" FontWeight="Medium" FontSize="14" Grid.Column="0" />
+                    <Button Grid.Column="1" Theme="{StaticResource CloseButton}" HorizontalAlignment="Right" Margin="0,0,10,0" Command="{Binding CloseWindowCommand, DataType=vm:ReleaseNotesDialogViewModel}" CommandParameter="{Binding ElementName=Window}"/>
+                </Grid>
+            </Border>
+            <Panel Grid.Row="1" Background="#323232">
+                <mdxaml:MarkdownScrollViewer Markdown="{Binding ReleaseNotes, DataType=vm:ReleaseNotesDialogViewModel}" Margin="10" ScrollViewer.AllowAutoHide="False">
+                    <mdxaml:MarkdownScrollViewer.Styles>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading1">
+                            <Setter Property="FontSize" Value="28"/>
+                        </Style>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading2">
+                            <Setter Property="FontSize" Value="24"/>
+                        </Style>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading3">
+                            <Setter Property="FontSize" Value="18"/>
+                        </Style>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer .List ctxt|CTextBlock">
+                            <Setter Property="FontSize" Value="14"/>
+                        </Style>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CHyperlink">
+                            <Style.Setters>
+                                <Setter Property="IsUnderline" Value="False" />
+                                <Setter Property="Foreground" Value="#3574F0" />
+                            </Style.Setters>
+                        </Style>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CHyperlink:pointerover">
+                            <Setter Property="Foreground" Value="#3574F0" />
+                        </Style>
+                    </mdxaml:MarkdownScrollViewer.Styles>
+                </mdxaml:MarkdownScrollViewer>
+            </Panel>
+            <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="10">
+                <CheckBox Grid.Column="0" VerticalAlignment="Center" Theme="{StaticResource CheckBox}" Content="Don't show this window after future updates." IsChecked="{Binding SuppressReleaseNotes, DataType=vm:ReleaseNotesDialogViewModel}" />
+                <Button Grid.Column="1" VerticalAlignment="Center" Theme="{StaticResource Dark}" FontSize="14" Content="Close Release Notes" Click="CloseWindow"/>
+            </Grid>
         </Grid>
     </Border>
 </Window>
-

--- a/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/ReleaseNotesDialog.axaml.cs
@@ -12,7 +12,7 @@ namespace Vatsim.Vatis.Ui.Dialogs;
 /// <summary>
 /// Represents a dialog that displays the release notes for the installed version.
 /// </summary>
-public partial class ReleaseNotesDialog : ReactiveWindow<ReleaseNotesDialogViewModel>
+public partial class ReleaseNotesDialog : ReactiveWindow<ReleaseNotesDialogViewModel>, ICloseable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ReleaseNotesDialog"/> class.
@@ -34,6 +34,6 @@ public partial class ReleaseNotesDialog : ReactiveWindow<ReleaseNotesDialogViewM
 
     private void CloseWindow(object? sender, RoutedEventArgs e)
     {
-        Close();
+        Close(DialogResult.Ok);
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/ReleaseNotesDialogViewModel.cs
@@ -3,6 +3,7 @@
 // Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Reactive;
 using ReactiveUI;
 using Vatsim.Vatis.Ui.Dialogs;
 
@@ -14,13 +15,23 @@ namespace Vatsim.Vatis.Ui.ViewModels;
 public class ReleaseNotesDialogViewModel : ReactiveViewModelBase
 {
     private string? _releaseNotes;
+    private bool _suppressReleaseNotes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReleaseNotesDialogViewModel"/> class.
     /// </summary>
     public ReleaseNotesDialogViewModel()
     {
+        CloseWindowCommand = ReactiveCommand.Create<ICloseable>(HandleCloseWindow);
     }
+
+    /// <summary>
+    /// Gets the command that closes the current window or dialog.
+    /// </summary>
+    /// <value>
+    /// A reactive command that takes an <see cref="ICloseable"/> instance as a parameter and performs the close operation.
+    /// </value>
+    public ReactiveCommand<ICloseable, Unit> CloseWindowCommand { get; }
 
     /// <summary>
     /// Gets or sets the release notes Markdown text.
@@ -29,5 +40,20 @@ public class ReleaseNotesDialogViewModel : ReactiveViewModelBase
     {
         get => _releaseNotes;
         set => this.RaiseAndSetIfChanged(ref _releaseNotes, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the release notes window should be shown.
+    /// When set to true, the release notes window will not be shown again.
+    /// </summary>
+    public bool SuppressReleaseNotes
+    {
+        get => _suppressReleaseNotes;
+        set => this.RaiseAndSetIfChanged(ref _suppressReleaseNotes, value);
+    }
+
+    private void HandleCloseWindow(ICloseable window)
+    {
+        window.Close(DialogResult.Ok);
     }
 }


### PR DESCRIPTION
- Tweaked styling of release notes window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now opt to hide future release notes using a new checkbox option. Release notes will only appear after an update if they haven’t been suppressed.

- **Style**
  - The release notes dialog has been redesigned with an updated layout and improved controls for a cleaner, more user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->