### PR TITLE
Fix airport conditions and NOTAM free-text

### DIFF
--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -59,10 +59,21 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
 
         if (ViewModel != null)
         {
+            // Assign empty read-only section providers before setting new ones
+            AirportConditions.TextArea.ReadOnlySectionProvider = new TextSegmentReadOnlySectionProvider<TextSegment>([]);
+            NotamText.TextArea.ReadOnlySectionProvider = new TextSegmentReadOnlySectionProvider<TextSegment>([]);
+
+            // Remove previous transformers
+            AirportConditions.TextArea.TextView.LineTransformers.Clear();
+            NotamText.TextArea.TextView.LineTransformers.Clear();
+
+            // Assign new read-only sections
             AirportConditions.TextArea.ReadOnlySectionProvider =
                 new TextSegmentReadOnlySectionProvider<TextSegment>(ViewModel.ReadOnlyAirportConditions);
             NotamText.TextArea.ReadOnlySectionProvider =
                 new TextSegmentReadOnlySectionProvider<TextSegment>(ViewModel.ReadOnlyNotams);
+
+            // Add new line transformers
             AirportConditions.TextArea.TextView.LineTransformers.Add(
                 new ReadOnlySegmentTransformer(ViewModel.ReadOnlyAirportConditions));
             NotamText.TextArea.TextView.LineTransformers.Add(

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
@@ -427,7 +427,17 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         if (SelectedPreset == null)
             return;
 
-        SelectedPreset.Notams = NotamsFreeText?[_notamFreeTextOffset..];
+        var freeText = "";
+
+        var readonlySegment = ReadOnlyNotams.FirstSegment;
+        if (readonlySegment != null)
+        {
+            freeText = readonlySegment.StartOffset > 0
+                ? NotamsTextDocument?.Text[..readonlySegment.StartOffset]
+                : NotamsTextDocument?.Text[readonlySegment.Length..];
+        }
+
+        SelectedPreset.Notams = string.IsNullOrEmpty(freeText) ? NotamsTextDocument?.Text.Trim() : freeText.Trim();
 
         if (_sessionManager.CurrentProfile != null)
             _profileRepository.Save(_sessionManager.CurrentProfile);
@@ -499,7 +509,20 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         if (SelectedPreset == null)
             return;
 
-        SelectedPreset.AirportConditions = AirportConditionsFreeText?[_airportConditionsFreeTextOffset..];
+        var freeText = "";
+
+        var readonlySegment = ReadOnlyAirportConditions.FirstSegment;
+        if (readonlySegment != null)
+        {
+            freeText = readonlySegment.StartOffset > 0
+                ? AirportConditionsTextDocument?.Text[..readonlySegment.StartOffset]
+                : AirportConditionsTextDocument?.Text[readonlySegment.Length..];
+        }
+
+        SelectedPreset.AirportConditions = string.IsNullOrEmpty(freeText)
+            ? AirportConditionsTextDocument?.Text.Trim()
+            : freeText.Trim();
+
         if (_sessionManager.CurrentProfile != null)
             _profileRepository.Save(_sessionManager.CurrentProfile);
 


### PR DESCRIPTION
- Fixed issue with free-text being duplicated on save in the sandbox.
- Fixed issue with read-only segments not being cleared correctly when viewmodel context changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the updating of text display areas to accurately reflect current data.
	- Enhanced the handling and saving of text inputs by properly managing read-only sections for a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->