### PR TITLE
Remove unused 'isOnline' parameter from constructor

### DIFF
--- a/vATIS.Desktop/Networking/AtisHub/Dto/AtisHubDto.cs
+++ b/vATIS.Desktop/Networking/AtisHub/Dto/AtisHubDto.cs
@@ -18,19 +18,17 @@ public class AtisHubDto
     /// <param name="stationId">The identifier of the station.</param>
     /// <param name="atisType">The type of ATIS.</param>
     /// <param name="atisLetter">The letter associated with the ATIS.</param>
-    /// <param name="isOnline">A value indicating whether the ATIS is connected.</param>
     /// <param name="metar">The METAR (Meteorological Aerodrome Report) information.</param>
     /// <param name="wind">The wind information.</param>
     /// <param name="altimeter">The altimeter setting.</param>
     /// <param name="airportConditions">The airport conditions.</param>
     /// <param name="notams">The NOTAMs.</param>
-    public AtisHubDto(string stationId, AtisType atisType, char atisLetter, bool isOnline, string? metar = null, string? wind = null,
+    public AtisHubDto(string stationId, AtisType atisType, char atisLetter, string? metar = null, string? wind = null,
         string? altimeter = null, string? airportConditions = null, string? notams = null)
     {
         StationId = stationId;
         AtisType = atisType;
         AtisLetter = atisLetter;
-        IsOnline = isOnline;
         Metar = metar;
         Wind = wind;
         Altimeter = altimeter;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -312,8 +312,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             if (NetworkConnectionStatus == NetworkConnectionStatus.Connected)
             {
-                _atisHubConnection.DisconnectAtis(
-                    new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType, AtisLetter, isOnline: false));
+                _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType, AtisLetter));
             }
 
             _voiceServerConnection.RemoveBot(_networkConnection.Callsign);
@@ -1028,7 +1027,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             await _voiceServerConnection.RemoveBot(_networkConnection.Callsign);
             _voiceServerConnection?.Disconnect();
 
-            await _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType, AtisLetter, isOnline: false));
+            await _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType, AtisLetter));
 
             // Dispose of the ATIS publish timer to stop further publishing.
             if (_publishAtisTimer != null)
@@ -1372,7 +1371,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             var notams = await Dispatcher.UIThread.InvokeAsync(() => NotamsTextDocument?.Text);
 
             await _atisHubConnection.PublishAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
-                AtisLetter, isOnline: true, Metar?.Trim(), Wind?.Trim(), Altimeter?.Trim(), airportConditions, notams));
+                AtisLetter, Metar?.Trim(), Wind?.Trim(), Altimeter?.Trim(), airportConditions, notams));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
The 'isOnline' value is set on the ATIS hub server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified connection management by removing redundant parameters during object instantiation.
	- Updated session handling to streamline disconnection and status publication, resulting in more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->