### PR TITLE
Increase max cloud groups to 6

### DIFF
--- a/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
+++ b/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
@@ -33,7 +33,7 @@ public sealed class CloudChunkDecoder : MetarChunkDecoder
     public override string GetRegex()
     {
         return
-            $"^({NoCloudRegexPattern}|({LayerRegexPattern})( {LayerRegexPattern})?( {LayerRegexPattern})?( {LayerRegexPattern})?)( )";
+            $"^({NoCloudRegexPattern}|({LayerRegexPattern})( {LayerRegexPattern})?( {LayerRegexPattern})?( {LayerRegexPattern})?( {LayerRegexPattern})?( {LayerRegexPattern})?)( )";
     }
 
     /// <summary>


### PR DESCRIPTION
FAA 7900.5E states that no more than 6 cloud layers are allowed, while ICAO Annex 3 only permits up to 4 cloud groups.