### PR TITLE
Add VSCode tasks for building nativeaudio

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,24 +1,57 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "type": "dotnet",
-      "task": "build vATIS.Desktop/vATIS.Desktop.csproj",
-      "file": "${workspaceFolder}/vATIS.Desktop/vATIS.Desktop.csproj",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "problemMatcher": [],
-      "label": "Build vATIS.Desktop"
-    },
-    {
-      "type": "dotnet",
-      "task": "build DevServer/DevServer.csproj",
-      "file": "${workspaceFolder}/DevServer/DevServer.csproj",
-      "group": "build",
-      "problemMatcher": [],
-      "label": "Build DevServer"
-    }
-  ]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "dotnet",
+            "task": "build vATIS.Desktop/vATIS.Desktop.csproj",
+            "file": "${workspaceFolder}/vATIS.Desktop/vATIS.Desktop.csproj",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [],
+            "label": "Build vATIS.Desktop"
+        },
+        {
+            "type": "dotnet",
+            "task": "build DevServer/DevServer.csproj",
+            "file": "${workspaceFolder}/DevServer/DevServer.csproj",
+            "group": "build",
+            "problemMatcher": [],
+            "label": "Build DevServer"
+        },
+        {
+            "type": "shell",
+            "label": "CMake - Generate build files",
+            "command": "cmake",
+            "args": [
+                "-S",
+                "./NativeAudio",
+                "-B",
+                "./NativeAudio/out",
+                "-G",
+                "Visual Studio 17 2022"
+            ],
+            "group": "build",
+            "problemMatcher": ["$gcc", "$msCompile"]
+        },
+        {
+            "type": "shell",
+            "label": "CMake - Build NativeAudio (Debug)",
+            "command": "cmake",
+            "args": ["--build", "./NativeAudio/out", "--config", "Debug"],
+            "group": "build",
+            "problemMatcher": ["$gcc", "$msCompile"],
+            "dependsOn": ["CMake - generate build files"]
+        },
+        {
+            "type": "shell",
+            "label": "CMake - Build NativeAudio (Release)",
+            "command": "cmake",
+            "args": ["--build", "./NativeAudio/out", "--config", "Release"],
+            "group": "build",
+            "problemMatcher": ["$gcc", "$msCompile"],
+            "dependsOn": ["CMake - generate build files"]
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -52,7 +52,7 @@
             "args": ["--build", "./NativeAudio/out", "--config", "Release"],
             "group": "build",
             "problemMatcher": ["$gcc", "$msCompile"],
-            "dependsOn": ["CMake - generate build files"]
+            "dependsOn": ["CMake - Generate build files"]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,7 +42,8 @@
             "args": ["--build", "./NativeAudio/out", "--config", "Debug"],
             "group": "build",
             "problemMatcher": ["$gcc", "$msCompile"],
-            "dependsOn": ["CMake - generate build files"]
+-            "dependsOn": ["CMake - generate build files"]
++            "dependsOn": ["CMake - Generate build files"]
         },
         {
             "type": "shell",


### PR DESCRIPTION
Adds three VSCode tasks related to building the native audio DLL:

* **CMake - Generate build files**: Runs the `cmake -S` command
* **CMake - Build NativeAudio (Debug)**: Runs the `cmake --build` command with `--config Debug`
* **CMake - Build NativeAudio (Release)**: Runs the `cmake --build` command with `--config Release`

The last two are dependent on the first to ensure the build files are always fresh prior to building the DLL.

These can be invoked with the **Task: Run Task** command in VSCode:

![image](https://github.com/user-attachments/assets/90496df0-6912-45a8-8319-b33ddd284a51)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new build capabilities to generate build files and compile the NativeAudio project.
	- Enabled streamlined Debug and Release build options.
	- Existing build workflows for other projects remain unchanged.
	- Added tasks for generating build files and building the NativeAudio project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->