### PR TITLE
Validate network connection

### DIFF
--- a/vATIS.Desktop/Networking/INetworkConnection.cs
+++ b/vATIS.Desktop/Networking/INetworkConnection.cs
@@ -50,6 +50,11 @@ public interface INetworkConnection
     event EventHandler<ClientEventArgs<string>> ChangeServerReceived;
 
     /// <summary>
+    /// Occurs when a PONG event is received.
+    /// </summary>
+    event EventHandler PongReceived;
+
+    /// <summary>
     /// Gets the callsign associated with the network connection.
     /// </summary>
     string Callsign { get; }

--- a/vATIS.Desktop/Networking/MockNetworkConnection.cs
+++ b/vATIS.Desktop/Networking/MockNetworkConnection.cs
@@ -79,6 +79,9 @@ public class MockNetworkConnection : INetworkConnection, IDisposable
     public event EventHandler<ClientEventArgs<string>>? ChangeServerReceived = (_, _) => { };
 
     /// <inheritdoc />
+    public event EventHandler? PongReceived = (_, _) => { };
+
+    /// <inheritdoc />
     public string Callsign { get; }
 
     /// <inheritdoc />

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1028,8 +1028,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             await _voiceServerConnection.RemoveBot(_networkConnection.Callsign);
             _voiceServerConnection?.Disconnect();
 
-            await _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
-                AtisLetter));
+            if (NetworkConnectionStatus == NetworkConnectionStatus.Connected)
+            {
+                await _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
+                    AtisLetter));
+            }
 
             // Dispose of the ATIS publish timer to stop further publishing.
             if (_publishAtisTimer != null)


### PR DESCRIPTION
Use PING/PONG to confirm FSD network connection before starting ATIS build. This workaround ensures we are properly connected to the network by sending a PING, and if the server responds with a PONG, we can safely proceed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved network connectivity monitoring with a new responsive event that triggers upon receiving a confirmation signal.
- **Refactor**
	- Enhanced disconnection logic to ensure the hub disconnects only when an active connection is detected, reducing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->