### PR TITLE
Only reset read-only segments if not observed ATIS

### DIFF
--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -59,6 +59,9 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
 
         if (ViewModel != null)
         {
+            if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
+                return;
+
             // Assign empty read-only section providers before setting new ones
             AirportConditions.TextArea.ReadOnlySectionProvider = new TextSegmentReadOnlySectionProvider<TextSegment>([]);
             NotamText.TextArea.ReadOnlySectionProvider = new TextSegmentReadOnlySectionProvider<TextSegment>([]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the station view behavior by conditionally bypassing unnecessary background processing for observer sessions, enhancing performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->