### PR TITLE
Unsaved airport conditions and NOTAMs

### DIFF
--- a/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
 using AvaloniaEdit.Document;
@@ -18,9 +19,6 @@ namespace Vatsim.Vatis.Ui.AtisConfiguration;
 /// </summary>
 public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
 {
-    private bool _airportConditionsInitialized;
-    private bool _notamsInitialized;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SandboxView"/> class.
     /// </summary>
@@ -138,15 +136,10 @@ public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
             if (vm.SelectedPreset == null)
                 return;
 
-            if (_airportConditionsInitialized)
-            {
-                if (!AirportConditions.TextArea.IsFocused)
-                    return;
+            if (!AirportConditions.TextArea.IsFocused)
+                return;
 
-                vm.HasUnsavedAirportConditions = true;
-            }
-
-            _airportConditionsInitialized = true;
+            vm.HasUnsavedAirportConditions = true;
         }
     }
 
@@ -157,15 +150,10 @@ public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
             if (vm.SelectedPreset == null)
                 return;
 
-            if (_notamsInitialized)
-            {
-                if (!NotamFreeText.TextArea.IsFocused)
-                    return;
+            if (!NotamFreeText.TextArea.IsFocused)
+                return;
 
-                vm.HasUnsavedNotams = true;
-            }
-
-            _notamsInitialized = true;
+            vm.HasUnsavedNotams = true;
         }
     }
 }

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -24,9 +24,6 @@ namespace Vatsim.Vatis.Ui.Components;
 /// </summary>
 public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
 {
-    private bool _airportConditionsInitialized;
-    private bool _notamsInitialized;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AtisStationView"/> class.
     /// </summary>
@@ -268,12 +265,7 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
         if (!AirportConditions.TextArea.IsFocused)
             return;
 
-        if (_airportConditionsInitialized)
-        {
-            ViewModel.HasUnsavedAirportConditions = true;
-        }
-
-        _airportConditionsInitialized = true;
+        ViewModel.HasUnsavedAirportConditions = true;
     }
 
     private void NotamText_OnTextChanged(object? sender, EventArgs e)
@@ -284,11 +276,6 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
         if (!NotamText.TextArea.IsFocused)
             return;
 
-        if (_notamsInitialized)
-        {
-            ViewModel.HasUnsavedNotams = true;
-        }
-
-        _notamsInitialized = true;
+        ViewModel.HasUnsavedNotams = true;
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -13,6 +13,7 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using AvaloniaEdit.CodeCompletion;
@@ -1435,6 +1436,23 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
             if (preset != _previousAtisPreset)
             {
+                if (HasUnsavedNotams || HasUnsavedAirportConditions)
+                {
+                    if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+                    {
+                        if (lifetime.MainWindow == null)
+                            return;
+
+                        if (await MessageBox.ShowDialog(lifetime.MainWindow,
+                                "You have unsaved Airport Conditions or NOTAMs. Would you like to save them first?",
+                                "Confirm", MessageBoxButton.YesNo, MessageBoxIcon.Information) == MessageBoxResult.Yes)
+                        {
+                            SaveNotamsText.Execute().Subscribe();
+                            SaveAirportConditionsText.Execute().Subscribe();
+                        }
+                    }
+                }
+
                 SelectedAtisPreset = preset;
                 _previousAtisPreset = preset;
 


### PR DESCRIPTION
- Enhance the logic to mark airport conditions and NOTAMs free-text as modified when changes occur in their respective textboxes.
- Prompt to save airport conditions and NOTAMs if there are unsaved changes before switching presets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When switching configurations, users are now prompted to confirm saving any unsaved changes, helping to prevent inadvertent data loss.

- **Refactor**
  - Streamlined handling of text input so that unsaved changes are flagged immediately, resulting in a smoother and more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->