### PR TITLE
Improve text ATIS formatting

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -280,21 +280,43 @@ public class AtisBuilder : IAtisBuilder
 
         foreach (var variable in variables)
         {
-            template = template.Replace($"[{variable.Find}:VOX]", variable.VoiceReplace);
-            template = template.Replace($"${variable.Find}:VOX", variable.VoiceReplace);
+            if (!string.IsNullOrEmpty(variable.VoiceReplace))
+            {
+                template = template.Replace($"[{variable.Find}:VOX]", variable.VoiceReplace);
+                template = template.Replace($"${variable.Find}:VOX", variable.VoiceReplace);
+            }
 
-            template = template.Replace($"[{variable.Find}]", variable.TextReplace);
-            template = template.Replace($"${variable.Find}", variable.TextReplace);
+            if (!string.IsNullOrEmpty(variable.TextReplace))
+            {
+                template = template.Replace($"[{variable.Find}]", variable.TextReplace);
+                template = template.Replace($"${variable.Find}", variable.TextReplace);
+            }
+            else
+            {
+                // Remove lines containing the variable placeholder if TextReplace is empty
+                template = Regex.Replace(template, $@"^.*(\[{variable.Find}\]|\${variable.Find}).*\r?\n?", "", RegexOptions.Multiline);
+            }
 
             if (variable.Aliases != null)
             {
                 foreach (var alias in variable.Aliases)
                 {
-                    template = template.Replace($"[{alias}:VOX]", variable.VoiceReplace);
-                    template = template.Replace($"${alias}:VOX", variable.VoiceReplace);
+                    if (!string.IsNullOrEmpty(variable.VoiceReplace))
+                    {
+                        template = template.Replace($"[{alias}:VOX]", variable.VoiceReplace);
+                        template = template.Replace($"${alias}:VOX", variable.VoiceReplace);
+                    }
 
-                    template = template.Replace($"[{alias}]", variable.TextReplace);
-                    template = template.Replace($"${alias}", variable.TextReplace);
+                    if (!string.IsNullOrEmpty(variable.TextReplace))
+                    {
+                        template = template.Replace($"[{alias}]", variable.TextReplace);
+                        template = template.Replace($"${alias}", variable.TextReplace);
+                    }
+                    else
+                    {
+                        // Remove lines containing the alias placeholder if TextReplace is empty
+                        template = Regex.Replace(template, $@"^.*(\[{alias}\]|\${alias}).*\r?\n?", "", RegexOptions.Multiline);
+                    }
                 }
             }
         }
@@ -340,9 +362,6 @@ public class AtisBuilder : IAtisBuilder
             closingTemplate = Regex.Replace(closingTemplate, @"{letter\|word}", currentAtisLetter.ToPhonetic());
             template += closingTemplate;
         }
-
-        // Remove text parsing characters
-        template = RemoveTextParsingCharacters(template);
 
         return template;
     }

--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -352,24 +352,7 @@ public class NetworkConnection : INetworkConnection, IDisposable
                 var num = 0;
                 if (_atisStation != null && !string.IsNullOrEmpty(_atisStation.TextAtis))
                 {
-                    List<string> collection;
-
-                    // Check if the text contains any line breaks
-                    if (_atisStation.TextAtis.Contains('\n') || _atisStation.TextAtis.Contains('\r'))
-                    {
-                        // Use existing line breaks
-                        collection =
-                        [
-                            .. _atisStation.TextAtis.Split(["\r\n", "\n", "\r"], StringSplitOptions.RemoveEmptyEntries)
-                        ];
-                    }
-                    else
-                    {
-                        // Break up the text into 64-character lines if no line breaks are present
-                        var regex = new Regex(@"(.{1,64})(?:\s|$)");
-                        collection = regex.Matches(_atisStation.TextAtis).Select(x => x.Groups[1].Value).ToList();
-                    }
-
+                    var collection = FormatAtisText(_atisStation.TextAtis);
                     foreach (var line in collection)
                     {
                         num++;
@@ -508,5 +491,21 @@ public class NetworkConnection : INetworkConnection, IDisposable
 
         _fsdSession.SendPdu(new PDUATCPosition(Callsign, _fsdFrequency, NetworkFacility.Twr, 50,
             _appConfig.NetworkRating, _airportData.Latitude, _airportData.Longitude));
+    }
+
+    private List<string> FormatAtisText(string atisText)
+    {
+        // Check if the text contains any line breaks
+        if (atisText.Contains('\n') || atisText.Contains('\r'))
+        {
+            // Use existing line breaks
+            return [.. atisText.Split(["\r\n", "\n", "\r"], StringSplitOptions.RemoveEmptyEntries)];
+        }
+        else
+        {
+            // Break up the text into 64-character lines if no line breaks are present
+            var regex = new Regex(@"(.{1,64})(?:\s|$)");
+            return regex.Matches(atisText).Select(x => x.Groups[1].Value).ToList();
+        }
     }
 }

--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -352,9 +352,24 @@ public class NetworkConnection : INetworkConnection, IDisposable
                 var num = 0;
                 if (_atisStation != null && !string.IsNullOrEmpty(_atisStation.TextAtis))
                 {
-                    // break up the text into 64 characters per line
-                    var regex = new Regex(@"(.{1,64})(?:\s|$)");
-                    var collection = regex.Matches(_atisStation.TextAtis).Select(x => x.Groups[1].Value).ToList();
+                    List<string> collection;
+
+                    // Check if the text contains any line breaks
+                    if (_atisStation.TextAtis.Contains('\n') || _atisStation.TextAtis.Contains('\r'))
+                    {
+                        // Use existing line breaks
+                        collection =
+                        [
+                            .. _atisStation.TextAtis.Split(["\r\n", "\n", "\r"], StringSplitOptions.RemoveEmptyEntries)
+                        ];
+                    }
+                    else
+                    {
+                        // Break up the text into 64-character lines if no line breaks are present
+                        var regex = new Regex(@"(.{1,64})(?:\s|$)");
+                        collection = regex.Matches(_atisStation.TextAtis).Select(x => x.Groups[1].Value).ToList();
+                    }
+
                     foreach (var line in collection)
                     {
                         num++;


### PR DESCRIPTION
- Don't unnecessarily strip text parsing characters from text ATIS
- Preserve existing line breaks in text ATIS before attempting to apply default line breaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced text replacement behavior: templates now apply replacements only when valid values are provided, resulting in cleaner outputs.
  - Improved text formatting: if ATIS content contains natural line breaks, they are preserved; otherwise, the text is automatically segmented for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->