### PR TITLE
Fix cloud parsing with missing cloud type

### DIFF
--- a/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
+++ b/vATIS.Desktop/Weather/Decoder/ChunkDecoder/CloudChunkDecoder.cs
@@ -24,7 +24,7 @@ public sealed class CloudChunkDecoder : MetarChunkDecoder
     private const string CeilingParameterName = "Ceiling";
     private const string CloudsParameterName = "Clouds";
     private const string NoCloudRegexPattern = "(NSC|NCD|CLR|SKC)";
-    private const string LayerRegexPattern = "(VV|FEW|SCT|BKN|OVC|///)([0-9]{3}|///)(CB|TCU|///)?";
+    private const string LayerRegexPattern = "(VV|FEW|SCT|BKN|OVC|///)?([0-9]{3}|///)(CB|TCU|///)?";
 
     /// <summary>
     /// Retrieves the regular expression pattern associated with the <see cref="CloudChunkDecoder"/> class.


### PR DESCRIPTION
VATIS-165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced weather data parsing to correctly handle cases where cloud amount information may be missing, ensuring more accurate and reliable weather condition displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->