### PR TITLE
Fix issue causing the preset template to be unintentionally cleared

### DIFF
--- a/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
@@ -69,6 +69,8 @@ public partial class PresetsView : UserControl
                         e.Handled = true;
                         return;
                     }
+
+                    model.HasUnsavedChanges = false;
                 }
 
                 if (e.AddedItems.Count > 0 && e.AddedItems[0] is AtisPreset preset)

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -121,6 +121,14 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
             }
         }
 
+        this.WhenAnyValue(x => x.HasUnsavedChanges).Subscribe(x =>
+        {
+            if (PresetsViewModel != null)
+            {
+                PresetsViewModel.HasUnsavedChanges = x;
+            }
+        });
+
         _atisStationSource.Connect()
             .AutoRefresh(x => x.Name)
             .AutoRefresh(x => x.AtisType)
@@ -233,7 +241,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
     public bool HasUnsavedChanges
     {
         get => _hasUnsavedChanges;
-        private set => this.RaiseAndSetIfChanged(ref _hasUnsavedChanges, value);
+        set => this.RaiseAndSetIfChanged(ref _hasUnsavedChanges, value);
     }
 
     /// <summary>

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
@@ -86,6 +86,8 @@ public partial class AtisConfigurationWindow : ReactiveWindow<AtisConfigurationW
                     e.Handled = true;
                     return;
                 }
+
+                model.HasUnsavedChanges = false;
             }
 
             if (e.AddedItems.Count > 0 && e.AddedItems[0] is AtisStation station)


### PR DESCRIPTION
The preset template could be unintentionally cleared when the user is prompted to discard unsaved changes when switching between stations/presets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of unsaved changes in configuration views. Now, when you confirm to discard changes during preset or station selections, the indicator resets immediately, ensuring a more consistent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->