### PR TITLE
Add variable for METAR observation day of month

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/ObservationTimeNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/ObservationTimeNode.cs
@@ -21,7 +21,7 @@ public class ObservationTimeNode : BaseNode<string>
     /// <inheritdoc/>
     public override void Parse(DecodedMetar metar)
     {
-        Parse(metar.Hour, metar.Minute);
+        Parse(metar.Day, metar.Hour, metar.Minute);
     }
 
     /// <inheritdoc/>
@@ -36,22 +36,23 @@ public class ObservationTimeNode : BaseNode<string>
         throw new NotImplementedException();
     }
 
-    private void Parse(int metarHour, int metarMinute)
+    private void Parse(int metarDay, int metarHour, int metarMinute)
     {
         ArgumentNullException.ThrowIfNull(Station);
 
         _isSpecialAtis = Station.AtisFormat.ObservationTime.StandardUpdateTime != null
                          && !Station.AtisFormat.ObservationTime.StandardUpdateTime.Contains(metarMinute);
 
-        VoiceAtis = ParseVoiceVariables(metarHour, metarMinute, Station.AtisFormat.ObservationTime.Template.Voice);
-        TextAtis = ParseTextVariables(metarHour, metarMinute, Station.AtisFormat.ObservationTime.Template.Text);
+        VoiceAtis = ParseVoiceVariables(metarDay, metarHour, metarMinute, Station.AtisFormat.ObservationTime.Template.Voice);
+        TextAtis = ParseTextVariables(metarDay, metarHour, metarMinute, Station.AtisFormat.ObservationTime.Template.Text);
     }
 
-    private string ParseTextVariables(int metarHour, int metarMinute, string? format)
+    private string ParseTextVariables(int metarDay, int metarHour, int metarMinute, string? format)
     {
         if (format == null)
             return "";
 
+        format = Regex.Replace(format, "{day}", $"{metarDay:00}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{time}", $"{metarHour:00}{metarMinute:00}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{hour}", $"{metarHour:00}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{minute}", $"{metarMinute:00}", RegexOptions.IgnoreCase);
@@ -60,11 +61,12 @@ public class ObservationTimeNode : BaseNode<string>
         return format;
     }
 
-    private string ParseVoiceVariables(int metarHour, int metarMinute, string? format)
+    private string ParseVoiceVariables(int metarDay, int metarHour, int metarMinute, string? format)
     {
         if (format == null)
             return "";
 
+        format = Regex.Replace(format, "{day}", metarDay.ToString("00").ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{time}", $"{metarHour.ToString("00").ToSerialFormat()} {metarMinute.ToString("00").ToSerialFormat()}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{hour}", metarHour.ToString("00").ToSerialFormat() ?? string.Empty, RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{minute}", metarMinute.ToString("00").ToSerialFormat() ?? string.Empty, RegexOptions.IgnoreCase);

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -45,7 +45,14 @@
 							<controls:TemplateVariableTextBox Text="{Binding ObservationTimeVoiceTemplate, DataType=vm:FormattingViewModel}" TextWrapping="Wrap" AcceptsReturn="True" Height="60" Theme="{StaticResource DarkTextBox}"/>
 						</StackPanel>
 						<StackPanel Orientation="Horizontal" Spacing="10">
-							<Button
+                            <Button
+                                Theme="{StaticResource DarkVariable}"
+                                ToolTip.Tip="The METAR observation day (e.g. 16)."
+                                Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
+                                CommandParameter="{Binding $self.Content}">
+                                {day}
+                            </Button>
+                            <Button
 								Theme="{StaticResource DarkVariable}"
 								ToolTip.Tip="The METAR observation time (e.g. 0153)."
 								Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -236,7 +236,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
     public ReadOnlyObservableCollection<AtisStation> AtisStations { get; set; }
 
     /// <summary>
-    /// Gets a value indicating whether there are unsaved changes in the current configuration of <see cref="AtisConfigurationWindowViewModel"/>.
+    /// Gets or sets a value indicating whether there are unsaved changes in the current configuration of <see cref="AtisConfigurationWindowViewModel"/>.
     /// </summary>
     public bool HasUnsavedChanges
     {

--- a/vATIS.Desktop/Weather/Decoder/Entity/DecodedMetar.cs
+++ b/vATIS.Desktop/Weather/Decoder/Entity/DecodedMetar.cs
@@ -120,7 +120,7 @@ public class DecodedMetar
     /// <summary>
     /// Gets or sets the day of this observation.
     /// </summary>
-    public int? Day { get; set; }
+    public int Day { get; set; }
 
     /// <summary>
     /// Gets or sets the time of the observation, as a string.


### PR DESCRIPTION
VATIS-145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced weather observations now include the day in both text and voice outputs.
  - A new configuration button lets users easily insert the observation day placeholder into formatting settings.
  - Improved data reliability ensures that observation day information is always consistently provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->