### PR TITLE
[VATIS-174] Re-subscribe to ATIS when disconnected due to duplicate callsign

### DIFF
--- a/Vatsim.Network/FSDSession.cs
+++ b/Vatsim.Network/FSDSession.cs
@@ -983,8 +983,8 @@ public class FsdSession
         {
             try
             {
-                _clientSocket.Shutdown(SocketShutdown.Both);
-                _clientSocket.Close();
+                _clientSocket?.Shutdown(SocketShutdown.Both);
+                _clientSocket?.Close();
             }
             catch (ObjectDisposedException) { }
             catch (SocketException) { }

--- a/vATIS.Desktop/Events/NetworkDisconnectedReceived.cs
+++ b/vATIS.Desktop/Events/NetworkDisconnectedReceived.cs
@@ -1,0 +1,28 @@
+// <copyright file="NetworkDisconnectedReceived.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+
+namespace Vatsim.Vatis.Events;
+
+/// <summary>
+/// Represents an event that is raised when a network disconnect is received.
+/// </summary>
+public class NetworkDisconnectedReceived : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NetworkDisconnectedReceived"/> class.
+    /// </summary>
+    /// <param name="callsignInUse">If the disconnect was caused by callsign in use.</param>
+    public NetworkDisconnectedReceived(bool callsignInUse = false)
+    {
+        CallsignInuse = callsignInUse;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the disconnect was because the callsign was in use.
+    /// </summary>
+    public bool CallsignInuse { get; set; }
+}

--- a/vATIS.Desktop/Networking/INetworkConnection.cs
+++ b/vATIS.Desktop/Networking/INetworkConnection.cs
@@ -22,7 +22,7 @@ public interface INetworkConnection
     /// <summary>
     /// Occurs when the network connection is terminated or unavailable.
     /// </summary>
-    event EventHandler NetworkDisconnected;
+    event EventHandler<NetworkDisconnectedReceived> NetworkDisconnected;
 
     /// <summary>
     /// Occurs when a network connection attempt fails.

--- a/vATIS.Desktop/Networking/MockNetworkConnection.cs
+++ b/vATIS.Desktop/Networking/MockNetworkConnection.cs
@@ -61,7 +61,7 @@ public class MockNetworkConnection : INetworkConnection, IDisposable
     public event EventHandler? NetworkConnected = (_, _) => { };
 
     /// <inheritdoc />
-    public event EventHandler? NetworkDisconnected = (_, _) => { };
+    public event EventHandler<NetworkDisconnectedReceived>? NetworkDisconnected = (_, _) => { };
 
     /// <inheritdoc />
     public event EventHandler? NetworkConnectionFailed = (_, _) => { };
@@ -109,7 +109,7 @@ public class MockNetworkConnection : INetworkConnection, IDisposable
         if (!string.IsNullOrEmpty(Station.Identifier))
             _metarRepository.RemoveMetar(Station.Identifier);
 
-        NetworkDisconnected?.Invoke(this, EventArgs.Empty);
+        NetworkDisconnected?.Invoke(this, new NetworkDisconnectedReceived());
         IsConnected = false;
 
         _previousMetar = null;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -236,7 +236,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
     public ReadOnlyObservableCollection<AtisStation> AtisStations { get; set; }
 
     /// <summary>
-    /// Gets a value indicating whether there are unsaved changes in the current configuration of <see cref="AtisConfigurationWindowViewModel"/>.
+    /// Gets or sets a value indicating whether there are unsaved changes in the current configuration of <see cref="AtisConfigurationWindowViewModel"/>.
     /// </summary>
     public bool HasUnsavedChanges
     {


### PR DESCRIPTION
Previously, when the ATIS was disconnected due to the callsign being in use, the observed ATIS letter would disappear. Re-subscribing will now restore the observed ATIS letter after disconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced network disconnection notifications now provide more detailed information—helping the app indicate when a duplicate callsign is causing disconnects.
  - Improved ATIS handling ensures that airport conditions and NOTAMs update accurately, and the ATIS indicator is stabilized upon reconnection.

- **Bug Fixes**
  - Strengthened the disconnection process to prevent unexpected errors during network shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->