### PR TITLE
Improve WS message consistency

### DIFF
--- a/vATIS.Desktop/Events/AcknowledgeAtisUpdateReceived.cs
+++ b/vATIS.Desktop/Events/AcknowledgeAtisUpdateReceived.cs
@@ -12,6 +12,12 @@ namespace Vatsim.Vatis.Events;
 /// Event arguments for the AcknowledgeAtisUpdateReceived event.
 /// </summary>
 /// <param name="Session">The client that requested the ATIS information.</param>
-/// <param name="Station">The station whose update is acknowledged. If null every station was acknowledged.</param>
+/// <param name="StationId">The station ID whose update is acknowledged.</param>
+/// <param name="Station">The station whose update is acknowledged.</param>
 /// <param name="AtisType">The ATIS Type whose update is acknowledged.</param>
-public record AcknowledgeAtisUpdateReceived(ClientMetadata Session, string? Station, AtisType? AtisType = AtisType.Combined) : IEvent;
+/// <remarks>If both <see cref="StationId"/> and <see cref="Station"/> are null, then every station is acknowledged.</remarks>
+public record AcknowledgeAtisUpdateReceived(
+    ClientMetadata Session,
+    string? StationId,
+    string? Station,
+    AtisType? AtisType = AtisType.Combined) : IEvent;

--- a/vATIS.Desktop/Events/GetAtisReceived.cs
+++ b/vATIS.Desktop/Events/GetAtisReceived.cs
@@ -12,6 +12,8 @@ namespace Vatsim.Vatis.Events;
 /// Event arguments for the GetAllAtisReceived event.
 /// </summary>
 /// <param name="Session">The client that requested the ATIS.</param>
-/// <param name="Station">The station requested. If null every station was requested.</param>
+/// <param name="StationId">The station ID requested.</param>
+/// <param name="Station">The station requested.</param>
 /// <param name="AtisType">The ATIS type requested.</param>
-public record GetAtisReceived(ClientMetadata Session, string? Station, AtisType? AtisType = AtisType.Combined) : IEvent;
+/// <remarks>If both <see cref="StationId"/> and <see cref="Station"/> are null, then every station is requested.</remarks>
+public record GetAtisReceived(ClientMetadata Session, string? StationId, string? Station, AtisType? AtisType = AtisType.Combined) : IEvent;

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/CommandMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/CommandMessage.cs
@@ -29,10 +29,18 @@ public class CommandMessage
     /// The values sent with a command, indicating the optional station and
     /// AtisType the command applies to.
     /// </summary>
+    /// <remarks>If both <see cref="StationId"/> and <see cref="Station"/>
+    /// are null, the command will apply to all stations.</remarks>
     public class CommandMessageValue
     {
         /// <summary>
-        /// Gets or sets the station the command is for. If null the command is for all stations.
+        /// Gets or sets the station ID the command is for.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? StationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the station the command is for.
         /// </summary>
         [JsonPropertyName("station")]
         public string? Station { get; set; }

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/LoadProfileMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/LoadProfileMessage.cs
@@ -32,7 +32,7 @@ public class LoadProfileMessage
         /// <summary>
         /// Gets or sets the profile ID.
         /// </summary>
-        [JsonPropertyName("profileId")]
+        [JsonPropertyName("id")]
         public string? ProfileId { get; set; }
     }
 }

--- a/vATIS.Desktop/Ui/Services/Websocket/WebsocketService.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/WebsocketService.cs
@@ -220,10 +220,13 @@ public class WebsocketService : IWebsocketService
             {
                 case "acknowledgeAtisUpdate":
                     AcknowledgeAtisUpdateReceived(this,
-                        new AcknowledgeAtisUpdateReceived(session, request.Value?.Station, request.Value?.AtisType));
+                        new AcknowledgeAtisUpdateReceived(session, request.Value?.StationId, request.Value?.Station,
+                            request.Value?.AtisType));
                     break;
                 case "getAtis":
-                    GetAtisReceived(this, new GetAtisReceived(session, request.Value?.Station, request.Value?.AtisType));
+                    GetAtisReceived(this,
+                        new GetAtisReceived(session, request.Value?.StationId, request.Value?.Station,
+                            request.Value?.AtisType));
                     break;
                 case "getProfiles":
                     HandleGetInstalledProfiles(session).SafeFireAndForget();

--- a/vATIS.Desktop/Ui/Services/Websocket/WebsocketService.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/WebsocketService.cs
@@ -159,6 +159,7 @@ public class WebsocketService : IWebsocketService
         }
         catch (Exception ex)
         {
+            Log.Error(ex, "WebSocket Exception");
             var error = new ErrorMessage { Value = new ErrorMessage.ErrorValue { Message = ex.Message, }, };
             await _server.SendAsync(e.Client.Guid,
                 JsonSerializer.Serialize(error, SourceGenerationContext.NewDefault.ErrorMessage));

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1802,15 +1802,20 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         try
         {
-            // If a specific station is specified then both the station identifier and the ATIS type
-            // must match to acknowledge the update.
-            // If a specific station isn't specified then the request is for all stations.
+            // If a specific station ID is provided, it must match the current station's ID.
+            if (!string.IsNullOrEmpty(e.StationId) && e.StationId != AtisStation.Id)
+            {
+                return;
+            }
+
+            // If a station identifier is provided, both the identifier and the ATIS type must match.
             if (!string.IsNullOrEmpty(e.Station) &&
                 (e.Station != AtisStation.Identifier || e.AtisType != AtisStation.AtisType))
             {
                 return;
             }
 
+            // If no specific station ID or identifier is provided, the request is treated as a request for all stations.
             await PublishAtisToWebsocket(e.Session);
         }
         catch (Exception ex)
@@ -1821,15 +1826,20 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void OnAcknowledgeAtisUpdateReceived(object? sender, AcknowledgeAtisUpdateReceived e)
     {
-        // If a specific station is specified then both the station identifier and the ATIS type
-        // must match to acknowledge the update.
-        // If a specific station isn't specified then the request is for all stations.
+        // If a specific station ID is provided, it must match the current station's ID.
+        if (!string.IsNullOrEmpty(e.StationId) && e.StationId != AtisStation.Id)
+        {
+            return;
+        }
+
+        // If a station identifier is provided, both the identifier and the ATIS type must match.
         if (!string.IsNullOrEmpty(e.Station) &&
             (e.Station != AtisStation.Identifier || e.AtisType != AtisStation.AtisType))
         {
             return;
         }
 
+        // If no specific station ID or identifier is provided, the request is treated as a request for all stations.
         HandleAcknowledgeAtisUpdate();
     }
 


### PR DESCRIPTION
- Use `id` property name for consistency
- Add `id` property to `getAtis` and `acknowledgeAtisUpdate` messages
- Throw exception to websocket client if both `id` and `station` are provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized handling of station identifiers in event notifications for greater clarity.
  - Updated JSON key mapping for profile identification to ensure consistent integration.
  
- **Documentation**
  - Enhanced descriptive notes clarifying behavior when station identification values are missing.
  
- **Bug Fixes**
  - Improved error logging for WebSocket communications.
  - Added stricter validation to prevent ambiguous station identifier inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->