### PR TITLE
Possible fix for null authentication token

### DIFF
--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -98,6 +98,9 @@ public class VoiceServerConnection : IVoiceServerConnection
     public async Task RemoveBot(string callsign, CancellationToken? cancellationToken = null)
     {
         if (_jwtToken == null)
+            await Authenticate();
+
+        if (_jwtToken == null)
             return;
 
         try

--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -70,6 +70,9 @@ public class VoiceServerConnection : IVoiceServerConnection
         try
         {
             if (_jwtToken == null)
+                await Authenticate();
+
+            if (_jwtToken == null)
                 throw new AtisBuilderException("AddOrUpdateBot failed because the authentication token is null.");
 
             // Remove existing bot


### PR DESCRIPTION
If token is null, try authenticating. If after authenticating the token is still null, then throw exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error handling to automatically attempt re-authentication when a valid token is missing, reducing potential interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->