### PR TITLE
Don't crash when app config is invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vatis",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reactive;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncAwaitBestPractices;
@@ -145,6 +146,11 @@ public class App : Application
                 }
                 catch (FileNotFoundException)
                 {
+                    appConfig.SaveConfig();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Unable to load app config, using default: {ex.Message}");
                     appConfig.SaveConfig();
                 }
 

--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -12,7 +12,6 @@ using System.Net;
 using System.Net.Http;
 using System.Reactive;
 using System.Reflection;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncAwaitBestPractices;


### PR DESCRIPTION
Catches all additional exceptions when attempting to load a config, and if one is thrown log a message and use the default config file.

Tested by editing my existing config so it was missing a quotation mark. Result is this in the log and a new, empty, config file getting created:

```
2025-04-03 06:12:00.176 -07:00 [ERR] Unable to load app config, using default: '0x0D' is invalid within a JSON string. The string should be correctly escaped. Path: $.name | LineNumber: 1 | BytePositionInLine: 19.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during application startup, ensuring that when configuration loading issues occur, the application seamlessly falls back to a default configuration, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->