### PR TITLE
Add parameter for centering messagebox dialog

### DIFF
--- a/vATIS.Desktop/Ui/Dialogs/MessageBox/MessageBox.cs
+++ b/vATIS.Desktop/Ui/Dialogs/MessageBox/MessageBox.cs
@@ -91,15 +91,17 @@ public static class MessageBox
     /// <param name="caption">The title of the message box.</param>
     /// <param name="button">The buttons to display in the message box. This parameter is of type <see cref="MessageBoxButton"/>.</param>
     /// <param name="icon">The icon to display in the message box. This parameter is of type <see cref="MessageBoxIcon"/>.</param>
+    /// <param name="centerWindow">A value indicating whether the dialog should be centered on the screen.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation, the result of which contains the <see cref="MessageBoxResult"/> selected by the user.</returns>
     public static async Task<MessageBoxResult> ShowDialog(
         Window owner,
         string messageBoxText,
         string caption,
         MessageBoxButton button,
-        MessageBoxIcon icon)
+        MessageBoxIcon icon,
+        bool centerWindow = false)
     {
-        return await ShowDialogCore(owner, messageBoxText, caption, button, icon);
+        return await ShowDialogCore(owner, messageBoxText, caption, button, icon, centerWindow);
     }
 
     private static Task<MessageBoxResult> ShowCore(
@@ -136,7 +138,8 @@ public static class MessageBox
         string messageBoxText,
         string caption,
         MessageBoxButton button,
-        MessageBoxIcon icon)
+        MessageBoxIcon icon,
+        bool centerWindow = false)
     {
         var viewModel = new MessageBoxViewModel
         {
@@ -145,6 +148,7 @@ public static class MessageBox
             Button = button,
             Icon = icon,
             Owner = owner,
+            CenterWindowOnScreen = centerWindow
         };
 
         var window = new MessageBoxView

--- a/vATIS.Desktop/Ui/Dialogs/MessageBox/MessageBoxView.axaml.cs
+++ b/vATIS.Desktop/Ui/Dialogs/MessageBox/MessageBoxView.axaml.cs
@@ -52,6 +52,19 @@ public partial class MessageBoxView : Window, ICloseable
     {
         if (DataContext is MessageBoxViewModel { Owner: not null } viewModel)
         {
+            if (viewModel.CenterWindowOnScreen)
+            {
+                var screen = Screens.ScreenFromVisual(this) ?? Screens.Primary;
+                if (screen != null)
+                {
+                    var screenBounds = screen.WorkingArea;
+                    Position = new PixelPoint(
+                        (int)(screenBounds.X + ((screenBounds.Width - Width) / 2)),
+                        (int)(screenBounds.Y + ((screenBounds.Height - Height) / 2)));
+                    return;
+                }
+            }
+
             var owner = viewModel.Owner;
             var ownerPosition = owner.Position;
 

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
@@ -133,7 +133,7 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
         {
             if (await MessageBox.ShowDialog((Window)_dialogOwner,
                     "You still have active ATIS connections. Are you sure you want to exit?", "Confirm",
-                    MessageBoxButton.YesNo, MessageBoxIcon.Warning) == MessageBoxResult.No)
+                    MessageBoxButton.YesNo, MessageBoxIcon.Warning, centerWindow: true) == MessageBoxResult.No)
             {
                 return false;
             }

--- a/vATIS.Desktop/Ui/ViewModels/MessageBoxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MessageBoxViewModel.cs
@@ -26,6 +26,7 @@ public class MessageBoxViewModel : ReactiveViewModelBase, IDisposable
     private bool _isYesVisible;
     private bool _isNoVisible;
     private bool _isCancelVisible;
+    private bool _centerWindowOnScreen;
     private string? _iconPath;
 
     /// <summary>
@@ -162,6 +163,15 @@ public class MessageBoxViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _iconPath;
         set => this.RaiseAndSetIfChanged(ref _iconPath, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the dialog show be centered on the screen.
+    /// </summary>
+    public bool CenterWindowOnScreen
+    {
+        get => _centerWindowOnScreen;
+        set => this.RaiseAndSetIfChanged(ref _centerWindowOnScreen, value);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Also, make exit confirmation dialog for mini-window centered on the screen (VATIS-180).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Message dialogs now include an option to be centered on the screen, enhancing visibility on multi-monitor setups.
	- Selected dialogs, including those tied to critical user sessions, now appear centered when the new feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->