### PR TITLE
Fix ATIS disconnect on local config update

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -362,7 +362,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }));
         _disposables.Add(EventBus.Instance.Subscribe<HubConnected>(_ =>
         {
-            _atisHubConnection.SubscribeToAtis(new SubscribeDto(AtisStation.Identifier, AtisStation.AtisType));
+            SubscribeToAtis();
         }));
         _disposables.Add(EventBus.Instance.Subscribe<SessionEnded>(_ =>
         {
@@ -725,6 +725,14 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
         // Set network connection status as disconnected
         NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;
+    }
+
+    /// <summary>
+    /// Subscribes to ATIS on hub server.
+    /// </summary>
+    public void SubscribeToAtis()
+    {
+        _atisHubConnection.SubscribeToAtis(new SubscribeDto(AtisStation.Identifier, AtisStation.AtisType));
     }
 
     /// <inheritdoc />
@@ -1270,7 +1278,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             if (e.CallsignInuse)
             {
                 // Subscribe to ATIS again if we were disconnected due to duplicate callsign
-                _atisHubConnection.SubscribeToAtis(new SubscribeDto(AtisStation.Identifier, AtisStation.AtisType));
+                SubscribeToAtis();
             }
         });
     }

--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using AsyncAwaitBestPractices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -176,7 +177,10 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
             var station = _atisStationSource.Items.FirstOrDefault(x => x.Id == evt.Id);
             if (station != null)
             {
-                _ = station.Disconnect();
+                if (station.NetworkConnectionStatus == NetworkConnectionStatus.Connected)
+                {
+                    station.Disconnect().SafeFireAndForget();
+                }
 
                 _disposables.Remove(station);
                 _atisStationSource.Remove(station);
@@ -185,6 +189,7 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
                 if (updatedStation != null)
                 {
                     var atisStationViewModel = _viewModelFactory.CreateAtisStationViewModel(updatedStation);
+                    atisStationViewModel.SubscribeToAtis();
                     _disposables.Add(atisStationViewModel);
                     _atisStationSource.Add(atisStationViewModel);
                 }


### PR DESCRIPTION
Fixes an issue where the observed ATIS station would be disconnected when the local station configuration was updated. Only trigger disconnect if the station connection status is connected (i.e. we are hosting it).

Also re-subscribe to ATIS after making changes to local configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized ATIS subscription logic into a single method for improved maintainability.
  - Improved handling of asynchronous disconnect operations for better reliability.
  - Enhanced control flow by checking connection status before disconnecting and ensuring subscriptions are set up for updated stations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->