### PR TITLE
Add toggle to mini-window to show or hide the METAR details

### DIFF
--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -41,6 +41,9 @@ public class AppConfig : IAppConfig
     public bool CompactWindowAlwaysOnTop { get; set; }
 
     /// <inheritdoc />
+    public bool CompactWindowShowMetarDetails { get; set; }
+
+    /// <inheritdoc />
     public WindowPosition? MainWindowPosition { get; set; }
 
     /// <inheritdoc />
@@ -97,6 +100,7 @@ public class AppConfig : IAppConfig
             SuppressNotificationSound = config.SuppressNotificationSound;
             AlwaysOnTop = config.AlwaysOnTop;
             CompactWindowAlwaysOnTop = config.CompactWindowAlwaysOnTop;
+            CompactWindowShowMetarDetails = config.CompactWindowShowMetarDetails;
             MainWindowPosition = config.MainWindowPosition;
             CompactWindowPosition = config.CompactWindowPosition;
             ProfileListDialogWindowPosition = config.ProfileListDialogWindowPosition;

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -53,6 +53,11 @@ public interface IAppConfig
     bool CompactWindowAlwaysOnTop { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the compact window should show the full METAR details.
+    /// </summary>
+    bool CompactWindowShowMetarDetails { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether the configuration is required.
     /// </summary>
     bool ConfigRequired { get; }

--- a/vATIS.Desktop/Ui/Styles/Buttons.axaml
+++ b/vATIS.Desktop/Ui/Styles/Buttons.axaml
@@ -21,8 +21,8 @@
 					<Button Theme="{StaticResource MinimizeButton}"/>
 					<Button Theme="{StaticResource CompactViewButton}"/>
 					<Button Theme="{StaticResource CloseButton}"/>
-					<Button Theme="{StaticResource SaveButton}"/>
 					<ToggleButton Theme="{StaticResource PinButton}"/>
+                    <ToggleButton Theme="{StaticResource ActionToggle}"/>
 				</StackPanel>
 			</StackPanel>
 		</Border>
@@ -381,6 +381,28 @@
 			<Setter Property="BorderBrush" Value="#dc6d62"/>
 		</Style>
 	</ControlTheme>
+
+    <ControlTheme x:Key="ActionToggle" BasedOn="{StaticResource Dark}" TargetType="ToggleButton">
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="Height" Value="19"/>
+        <Setter Property="MinHeight" Value="19"/>
+        <Setter Property="CornerRadius" Value="3"/>
+        <Setter Property="Width" Value="19"/>
+        <Setter Property="Content">
+            <Template>
+                <Viewbox Width="19" Height="19" Stretch="Uniform">
+                    <Canvas Width="256" Height="256">
+                        <Path Stroke="Transparent" Fill="White"
+                              Data="M156,128a28,28,0,1,1-28-28A28.02769,28.02769,0,0,1,156,128ZM48,100a28,28,0,1,0,28,28A28.02769,28.02769,0,0,0,48,100Zm160,0a28,28,0,1,0,28,28A28.02769,28.02769,0,0,0,208,100Z" />
+                    </Canvas>
+                </Viewbox>
+            </Template>
+        </Setter>
+        <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#C0392B"/>
+            <Setter Property="BorderBrush" Value="#C0392B"/>
+        </Style>
+    </ControlTheme>
 
     <ControlTheme x:Key="PinButtonSmall" BasedOn="{StaticResource Dark}" TargetType="ToggleButton">
         <Setter Property="Padding" Value="4"/>

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowTopMostViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowTopMostViewModel.cs
@@ -20,10 +20,12 @@ public class CompactWindowTopMostViewModel : ReactiveViewModelBase, IDisposable
 
     private IAppConfig? _appConfig;
     private bool _isTopMost;
+    private bool _showMetarDetails;
 
     private CompactWindowTopMostViewModel()
     {
         ToggleIsTopMost = ReactiveCommand.Create(HandleToggleIsTopMost);
+        ToggleMetarDetails = ReactiveCommand.Create(HandleToggleMetarDetails);
     }
 
     /// <summary>
@@ -37,12 +39,27 @@ public class CompactWindowTopMostViewModel : ReactiveViewModelBase, IDisposable
     public ReactiveCommand<Unit, Unit> ToggleIsTopMost { get; private set; }
 
     /// <summary>
+    /// Gets the command that toggles the display of the METAR details (wind and altimeter) in the compact window.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> ToggleMetarDetails { get; private set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the compact window is displayed as the topmost window.
     /// </summary>
     public bool IsTopMost
     {
         get => _isTopMost;
         set => this.RaiseAndSetIfChanged(ref _isTopMost, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the METAR details (wind and altimeter) are displayed in
+    /// the compact window. If false, only the station ID and ATIS letter are shown.
+    /// </summary>
+    public bool ShowMetarDetails
+    {
+        get => _showMetarDetails;
+        set => this.RaiseAndSetIfChanged(ref _showMetarDetails, value);
     }
 
     /// <summary>
@@ -53,12 +70,14 @@ public class CompactWindowTopMostViewModel : ReactiveViewModelBase, IDisposable
     {
         _appConfig = appConfig;
         IsTopMost = _appConfig.CompactWindowAlwaysOnTop;
+        ShowMetarDetails = _appConfig.CompactWindowShowMetarDetails;
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        ToggleIsTopMost?.Dispose();
+        ToggleIsTopMost.Dispose();
+        ToggleMetarDetails.Dispose();
 
         GC.SuppressFinalize(this);
     }
@@ -70,6 +89,17 @@ public class CompactWindowTopMostViewModel : ReactiveViewModelBase, IDisposable
         if (_appConfig != null)
         {
             _appConfig.CompactWindowAlwaysOnTop = IsTopMost;
+            _appConfig.SaveConfig();
+        }
+    }
+
+    private void HandleToggleMetarDetails()
+    {
+        ShowMetarDetails = !ShowMetarDetails;
+
+        if (_appConfig != null)
+        {
+            _appConfig.CompactWindowShowMetarDetails = ShowMetarDetails;
             _appConfig.SaveConfig();
         }
     }

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -10,7 +10,7 @@
         x:Name="Window"
         x:Class="Vatsim.Vatis.Ui.Windows.CompactWindow"
         MinHeight="30"
-        MinWidth="100"
+        MinWidth="90"
         MaxWidth="400"
         SizeToContent="WidthAndHeight"
         Background="Transparent"
@@ -22,6 +22,24 @@
         Title="vATIS">
     <Window.Resources>
         <converter:AtisLetterColorConverter x:Key="AtisLetterColorConverter"/>
+        <DataTemplate x:Key="AtisLetterTemplate">
+            <TextBlock
+                Name="AtisLetter"
+                FontFamily="{StaticResource Monospace}"
+                FontSize="15"
+                FontWeight="Medium"
+                Text="{Binding AtisLetter, DataType=vm:AtisStationViewModel}"
+                Foreground="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource AtisLetterColorConverter}, FallbackValue=Aqua}" Cursor="Hand">
+                <Interaction.Behaviors>
+                    <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="AtisLetter">
+                        <InvokeCommandAction Command="{Binding AcknowledgeAtisUpdateCommand, DataType=vm:AtisStationViewModel}" />
+                    </RoutedEventTriggerBehavior>
+                    <behaviors:BlinkingTextBehavior
+                        IsEnabled="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}"
+                        IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel}" />
+                </Interaction.Behaviors>
+            </TextBlock>
+        </DataTemplate>
     </Window.Resources>
     <Border CornerRadius="5"
             BorderBrush="Black"
@@ -33,6 +51,7 @@
             PointerPressed="OnPointerPressed">
         <Panel ClipToBounds="True">
             <StackPanel Name="WindowControls" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" Spacing="3" ZIndex="1" Margin="3" IsVisible="{Binding IsControlsVisible, DataType=vm:CompactWindowViewModel}">
+                <ToggleButton Theme="{StaticResource ActionToggle}" Command="{Binding ToggleMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" IsChecked="{Binding ShowMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Mode=OneWay, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" />
                 <ToggleButton Theme="{StaticResource PinButtonSmall}" Command="{Binding ToggleIsTopMost, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" IsChecked="{Binding IsTopMost, DataType=vm:CompactWindowTopMostViewModel, Mode=OneWay, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" />
                 <Button Theme="{StaticResource CompactViewButtonSmall}" Command="{Binding InvokeMainWindowCommand, DataType=vm:CompactWindowViewModel}" CommandParameter="{Binding ElementName=Window}" />
             </StackPanel>
@@ -40,17 +59,14 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal" Spacing="5">
-                            <Grid ColumnDefinitions="65,10,60,10,Auto,15,Auto">
+                            <Grid ColumnDefinitions="65,10" IsVisible="{Binding !ShowMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}">
+                                <TextBlock Grid.Column="0" FontFamily="{StaticResource Monospace}" FontSize="15" FontWeight="Medium" Foreground="White" Text="{Binding TabText, DataType=vm:AtisStationViewModel}" />
+                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource AtisLetterTemplate}" Grid.Column="1"/>
+                            </Grid>
+                            <Grid ColumnDefinitions="65,10,60,10,Auto,15,Auto" IsVisible="{Binding ShowMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}">
                                 <TextBlock Grid.Column="0" FontFamily="{StaticResource Monospace}" FontSize="15" FontWeight="Medium" Foreground="White" Text="{Binding TabText, DataType=vm:AtisStationViewModel}" />
                                 <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="5">
-                                    <TextBlock Name="AtisLetter" FontFamily="{StaticResource Monospace}" FontSize="15" FontWeight="Medium" Text="{Binding AtisLetter, DataType=vm:AtisStationViewModel}" Foreground="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource AtisLetterColorConverter}, FallbackValue=Aqua}" Cursor="Hand">
-                                        <Interaction.Behaviors>
-                                            <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="AtisLetter">
-                                                <InvokeCommandAction Command="{Binding AcknowledgeAtisUpdateCommand, DataType=vm:AtisStationViewModel}"/>
-                                            </RoutedEventTriggerBehavior>
-                                            <behaviors:BlinkingTextBehavior IsEnabled="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}" IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel}"/>
-                                        </Interaction.Behaviors>
-                                    </TextBlock>
+                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource AtisLetterTemplate}" />
                                     <TextBlock Text="{Binding ObservationTime, DataType=vm:AtisStationViewModel}" Foreground="White" FontSize="15" FontWeight="Medium"/>
                                 </StackPanel>
                                 <TextBlock Grid.Column="4" FontFamily="{StaticResource Monospace}" FontSize="15" FontWeight="Medium" Text="{Binding Altimeter, DataType=vm:AtisStationViewModel}" Foreground="White"/>


### PR DESCRIPTION
If toggled, the mini-window will show all METAR details: station ID, ATIS letter, time, wind, altimeter. If toggled false, it will only show the station ID and ATIS letter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toggle button in the compact window to show or hide detailed METAR information, including wind and altimeter data.
  - Introduced a new visual style for the toggle button.
  - Added a reusable template for displaying the ATIS letter with improved styling and interaction.

- **Style**
  - Reduced the minimum width of the compact window for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->