### PR TITLE
[VATIS-178] Add getActiveProfile and getContractions websocket messages

### DIFF
--- a/vATIS.Desktop/Sessions/SessionManager.cs
+++ b/vATIS.Desktop/Sessions/SessionManager.cs
@@ -86,6 +86,10 @@ public class SessionManager : ISessionManager
     {
         try
         {
+            var profile = (await _profileRepository.LoadAll()).Find(p => p.Id == profileId);
+            if (profile == null)
+                return;
+
             EndSession();
             await StartSession(profileId);
         }

--- a/vATIS.Desktop/SourceGenerationContext.cs
+++ b/vATIS.Desktop/SourceGenerationContext.cs
@@ -66,6 +66,8 @@ namespace Vatsim.Vatis;
 [JsonSerializable(typeof(DisconnectAtisMessage))]
 [JsonSerializable(typeof(LoadProfileMessage))]
 [JsonSerializable(typeof(InstalledProfilesMessage))]
+[JsonSerializable(typeof(ActiveProfileMessage))]
+[JsonSerializable(typeof(List<ContractionsResponseMessage>))]
 [JsonSerializable(typeof(DigitalAtisRequestDto))]
 [JsonSerializable(typeof(List<DigitalAtisResponseDto>))]
 [JsonSerializable(typeof(JsonElement))]

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/ActiveProfileMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/ActiveProfileMessage.cs
@@ -1,0 +1,32 @@
+// <copyright file="ActiveProfileMessage.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Text.Json.Serialization;
+
+namespace Vatsim.Vatis.Ui.Services.Websocket.Messages;
+
+/// <summary>
+/// Represents a websocket message that returns the active profile.
+/// </summary>
+public class ActiveProfileMessage
+{
+    /// <summary>
+    /// Gets the string identifying the message type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string MessageType => "getActiveProfile";
+
+    /// <summary>
+    /// Gets or sets the ID of the active profile.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the active profile.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
@@ -10,7 +10,7 @@ using Vatsim.Vatis.Profiles.Models;
 namespace Vatsim.Vatis.Ui.Services.Websocket.Messages;
 
 /// <summary>
-/// Represents a websocket message that returns the contractions for a specific ATIS station.
+/// Represents a websocket message that returns the contractions for ATIS stations.
 /// </summary>
 public class ContractionsResponseMessage
 {
@@ -50,7 +50,7 @@ public class ContractionsResponseMessage
         public AtisType? AtisType { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of contractions.
+        /// Gets or sets the dictionary of contractions, where the key is the contraction identifier.
         /// </summary>
         [JsonPropertyName("contractions")]
         public Dictionary<string, ContractionDetail>? Contractions { get; set; }

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
@@ -1,0 +1,76 @@
+// <copyright file="ContractionsResponseMessage.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Ui.Services.Websocket.Messages;
+
+/// <summary>
+/// Represents a websocket message that returns the contractions for a specific ATIS station.
+/// </summary>
+public class ContractionsResponseMessage
+{
+    /// <summary>
+    /// Gets the string identifying the message type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string MessageType => "getContractions";
+
+    /// <summary>
+    /// Gets or sets a list of stations and their contractions.
+    /// </summary>
+    [JsonPropertyName("stations")]
+    public List<StationContractions>? Stations { get; set; }
+
+    /// <summary>
+    /// Represents an individual station and the contractions.
+    /// </summary>
+    public class StationContractions
+    {
+        /// <summary>
+        /// Gets or sets the station ID.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the station.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the station ATIS type.
+        /// </summary>
+        [JsonPropertyName("atisType")]
+        public AtisType? AtisType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of contractions.
+        /// </summary>
+        [JsonPropertyName("contractions")]
+        public Dictionary<string, ContractionDetail>? Contractions { get; set; }
+
+        /// <summary>
+        /// Represents an individual contraction.
+        /// </summary>
+        public class ContractionDetail
+        {
+            /// <summary>
+            /// Gets or sets the text value.
+            /// </summary>
+            [JsonPropertyName("text")]
+            public string? Text { get; set; }
+
+            /// <summary>
+            /// Gets or sets the voice value.
+            /// </summary>
+            [JsonPropertyName("voice")]
+            public string? Voice { get; set; }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving and sending the current active profile information via WebSocket.
  - Introduced a new WebSocket message to provide contractions data for ATIS stations, with detailed station and contraction information.

- **Bug Fixes**
  - Improved profile switching logic to prevent errors when a non-existent profile is selected.

- **Improvements**
  - Enhanced logging for better error tracking in WebSocket sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->