### PR TITLE
Add voice server heartbeat

### DIFF
--- a/vATIS.Desktop/Io/Downloader.cs
+++ b/vATIS.Desktop/Io/Downloader.cs
@@ -64,8 +64,15 @@ public class Downloader : IDownloader
     }
 
     /// <inheritdoc />
-    public Task<HttpResponseMessage> GetAsync(string url)
+    public Task<HttpResponseMessage> GetAsync(string url, string? jwtToken = null)
     {
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+        if (!string.IsNullOrEmpty(jwtToken))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+        }
+
         return _httpClient.GetAsync(url);
     }
 

--- a/vATIS.Desktop/Io/Downloader.cs
+++ b/vATIS.Desktop/Io/Downloader.cs
@@ -66,14 +66,13 @@ public class Downloader : IDownloader
     /// <inheritdoc />
     public Task<HttpResponseMessage> GetAsync(string url, string? jwtToken = null)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
         if (!string.IsNullOrEmpty(jwtToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
         }
 
-        return _httpClient.GetAsync(url);
+        return _httpClient.SendAsync(request);
     }
 
     /// <inheritdoc />
@@ -105,44 +104,51 @@ public class Downloader : IDownloader
     public async Task<HttpResponseMessage> PostJsonResponse(string url, string content, string? jwtToken = null,
         CancellationToken? cancellationToken = null)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        };
+
         if (!string.IsNullOrEmpty(jwtToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
         }
 
-        return await _httpClient.PostAsync(url, new StringContent(content, Encoding.UTF8, "application/json"),
-            cancellationToken.GetValueOrDefault());
+        return await _httpClient.SendAsync(request, cancellationToken: cancellationToken.GetValueOrDefault());
     }
 
     /// <inheritdoc />
     public async Task PostJson(string url, string content, string? jwtToken = null,
         CancellationToken? cancellationToken = null)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        };
+
         if (!string.IsNullOrEmpty(jwtToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
         }
 
-        await _httpClient.PostAsync(url, new StringContent(content, Encoding.UTF8, "application/json"),
-            cancellationToken.GetValueOrDefault());
+        await _httpClient.SendAsync(request, cancellationToken: cancellationToken.GetValueOrDefault());
     }
 
     /// <inheritdoc />
-    public async Task<HttpResponseMessage> PutJson(string url, string jsonContent, string? jwtToken = null, CancellationToken? cancellationToken = null)
+    public async Task<HttpResponseMessage> PutJson(string url, string jsonContent, string? jwtToken = null,
+        CancellationToken? cancellationToken = null)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
+        var request = new HttpRequestMessage(HttpMethod.Put, url)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, "application/json")
+        };
+
         if (!string.IsNullOrEmpty(jwtToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
         }
 
-        return await _httpClient.PutAsync(url, new StringContent(jsonContent, Encoding.UTF8, "application/json"),
-            cancellationToken.GetValueOrDefault());
+        return await _httpClient.SendAsync(request, cancellationToken: cancellationToken.GetValueOrDefault());
     }
 
     /// <inheritdoc />
@@ -158,14 +164,14 @@ public class Downloader : IDownloader
     /// <inheritdoc />
     public async Task Delete(string url, string? jwtToken = null, CancellationToken? cancellationToken = null)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
+        var request = new HttpRequestMessage(HttpMethod.Delete, url);
+
         if (!string.IsNullOrEmpty(jwtToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
         }
 
-        await _httpClient.DeleteAsync(url, cancellationToken.GetValueOrDefault());
+        await _httpClient.SendAsync(request, cancellationToken: cancellationToken.GetValueOrDefault());
     }
 
     private async Task DownloadToStreamAsync(string url, Stream stream, IProgress<int>? progress)

--- a/vATIS.Desktop/Io/IDownloader.cs
+++ b/vATIS.Desktop/Io/IDownloader.cs
@@ -21,7 +21,7 @@ public interface IDownloader
     /// </summary>
     /// <param name="url">The URL to request.</param>
     /// <returns>A task representing the asynchronous operation, containing the HTTP response message.</returns>
-    Task<HttpResponseMessage> GetAsync(string url);
+    Task<HttpResponseMessage> GetAsync(string url, string? jwtToken = null);
 
     /// <summary>
     /// Downloads the content of the specified URL as a string.

--- a/vATIS.Desktop/Io/IDownloader.cs
+++ b/vATIS.Desktop/Io/IDownloader.cs
@@ -20,6 +20,8 @@ public interface IDownloader
     /// Performs an HTTP GET request to the specified URL.
     /// </summary>
     /// <param name="url">The URL to request.</param>
+    /// <param name="jwtToken">Optional JWT bearer token that will be sent as an <c>Authorized</c> header.
+    /// Provide <c>null</c> for unauthenticated requests.</param>
     /// <returns>A task representing the asynchronous operation, containing the HTTP response message.</returns>
     Task<HttpResponseMessage> GetAsync(string url, string? jwtToken = null);
 
@@ -52,7 +54,8 @@ public interface IDownloader
     /// </summary>
     /// <param name="url">The URL to download.</param>
     /// <param name="jsonContent">The JSON content to post.</param>
-    /// <param name="jwtToken">The JWT token to include in the request header.</param>
+    /// <param name="jwtToken">Optional JWT bearer token that will be sent as an <c>Authorized</c> header.
+    /// Provide <c>null</c> for unauthenticated requests.</param>
     /// <param name="cancellationToken">An optional cancellation token for cancelling the operation.</param>
     /// <returns>A task representing the asynchronous operation, containing the downloaded stream.</returns>
     Task<HttpResponseMessage> PostJsonResponse(
@@ -67,7 +70,8 @@ public interface IDownloader
     /// </summary>
     /// <param name="url">The URL to download.</param>
     /// <param name="jsonContent">The JSON content to post.</param>
-    /// <param name="jwtToken">The JWT token to include in the request header.</param>
+    /// <param name="jwtToken">Optional JWT bearer token that will be sent as an <c>Authorized</c> header.
+    /// Provide <c>null</c> for unauthenticated requests.</param>
     /// <param name="cancellationToken">An optional cancellation token for cancelling the operation.</param>
     /// <returns>A task representing the asynchronous operation, containing the downloaded stream.</returns>
     Task PostJson(string url, string jsonContent, string? jwtToken = null, CancellationToken? cancellationToken = null);
@@ -76,7 +80,8 @@ public interface IDownloader
     /// Send a DELETE request to the specified URL.
     /// </summary>
     /// <param name="url">The URL to request.</param>
-    /// <param name="jwtToken">The JWT token to include in the request header.</param>
+    /// <param name="jwtToken">Optional JWT bearer token that will be sent as an <c>Authorized</c> header.
+    /// Provide <c>null</c> for unauthenticated requests.</param>
     /// <param name="cancellationToken">An optional cancellation token for cancelling the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task Delete(string url, string? jwtToken = null, CancellationToken? cancellationToken = null);
@@ -86,7 +91,8 @@ public interface IDownloader
     /// </summary>
     /// <param name="url">The URL to request.</param>
     /// <param name="jsonContent">The JSON content to send.</param>
-    /// <param name="jwtToken">The JWT token to include in the request header.</param>
+    /// <param name="jwtToken">Optional JWT bearer token that will be sent as an <c>Authorized</c> header.
+    /// Provide <c>null</c> for unauthenticated requests.</param>
     /// <param name="cancellationToken">An optional cancellation token for cancelling the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task<HttpResponseMessage> PutJson(

--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -83,6 +83,11 @@ public class VoiceServerConnection : IVoiceServerConnection
                 cancellationToken);
             response.EnsureSuccessStatusCode();
 
+            if (_heartbeatTimer != null)
+            {
+                await _heartbeatTimer.DisposeAsync();
+            }
+
             _heartbeatTimer = new Timer(HeartbeatTimerCallback, callsign, s_heartbeatInterval, s_heartbeatInterval);
 
             Log.Information($"AddOrUpdateBot: {callsign}");

--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -90,7 +90,7 @@ public class VoiceServerConnection : IVoiceServerConnection
 
             _heartbeatTimer = new Timer(HeartbeatTimerCallback, callsign, s_heartbeatInterval, s_heartbeatInterval);
 
-            Log.Information($"AddOrUpdateBot: {callsign}");
+            Log.Information("AddOrUpdateBot: {Callsign}", callsign);
         }
         catch (OperationCanceledException)
         {
@@ -98,7 +98,7 @@ public class VoiceServerConnection : IVoiceServerConnection
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"AddOrUpdateBot Failed: {callsign}");
+            Log.Error(ex, "AddOrUpdateBot Failed: {Callsign}", callsign);
             throw new AtisBuilderException("AddOrUpdateBot Failed: " + ex.Message);
         }
     }
@@ -115,7 +115,7 @@ public class VoiceServerConnection : IVoiceServerConnection
         try
         {
             await _downloader.Delete(VoiceServerUrl + "/api/v1/bots/" + callsign, _jwtToken, cancellationToken);
-            Log.Information($"RemoveBot: {callsign}");
+            Log.Information("RemoveBot: {Callsign}", callsign);
 
             if (_heartbeatTimer != null)
             {
@@ -125,7 +125,7 @@ public class VoiceServerConnection : IVoiceServerConnection
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"RemoveBot Failed: {callsign}");
+            Log.Error(ex, "RemoveBot Failed: {Callsign}", callsign);
             throw new AtisBuilderException("RemoveBot Failed: " + ex.Message);
         }
     }
@@ -163,7 +163,7 @@ public class VoiceServerConnection : IVoiceServerConnection
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"SendHeartbeatAsync failed for callsign {callsign}");
+            Log.Error(ex, "SendHeartbeatAsync failed for callsign {Callsign}", callsign);
         }
     }
 

--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -151,8 +151,15 @@ public class VoiceServerConnection : IVoiceServerConnection
 
         try
         {
-            await _downloader.GetAsync($"{VoiceServerUrl}/api/v1/bots/{callsign}/heartbeat", _jwtToken);
-            Log.Information($"Heartbeat: {callsign}");
+            var response = await _downloader.GetAsync($"{VoiceServerUrl}/api/v1/bots/{callsign}/heartbeat", _jwtToken);
+            if (response.IsSuccessStatusCode)
+            {
+                Log.Information("Heartbeat: {Callsign}", callsign);
+            }
+            else
+            {
+                Log.Warning("Heartbeat failed for {Callsign} – {StatusCode}", callsign, response.StatusCode);
+            }
         }
         catch (Exception ex)
         {

--- a/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/VoiceServerConnection.cs
@@ -7,6 +7,7 @@ using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using AsyncAwaitBestPractices;
 using Serilog;
 using Vatsim.Vatis.Atis;
 using Vatsim.Vatis.Config;
@@ -23,10 +24,12 @@ public class VoiceServerConnection : IVoiceServerConnection
     private const string ClientName = "vATIS";
     private const string VoiceServerUrl = "https://voice1.vatsim.net";
     private static readonly TimeSpan s_tokenRefreshInterval = TimeSpan.FromMinutes(55);
+    private static readonly TimeSpan s_heartbeatInterval = TimeSpan.FromSeconds(30);
 
     private readonly IDownloader _downloader;
     private readonly IAppConfig _appConfig;
     private Timer? _refreshTokenTimer;
+    private Timer? _heartbeatTimer;
     private string? _jwtToken;
 
     /// <summary>
@@ -80,7 +83,9 @@ public class VoiceServerConnection : IVoiceServerConnection
                 cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            Log.Information($"AddOrUpdateBot successful for {callsign}.");
+            _heartbeatTimer = new Timer(HeartbeatTimerCallback, callsign, s_heartbeatInterval, s_heartbeatInterval);
+
+            Log.Information($"AddOrUpdateBot: {callsign}");
         }
         catch (OperationCanceledException)
         {
@@ -88,8 +93,8 @@ public class VoiceServerConnection : IVoiceServerConnection
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "AddOrUpdateBot failed for callsign {Callsign}", callsign);
-            throw new AtisBuilderException("AddOrUpdateBot action failed: " + ex.Message);
+            Log.Error(ex, $"AddOrUpdateBot Failed: {callsign}");
+            throw new AtisBuilderException("AddOrUpdateBot Failed: " + ex.Message);
         }
     }
 
@@ -105,12 +110,48 @@ public class VoiceServerConnection : IVoiceServerConnection
         try
         {
             await _downloader.Delete(VoiceServerUrl + "/api/v1/bots/" + callsign, _jwtToken, cancellationToken);
-            Log.Information($"RemoveBot successful for {callsign}.");
+            Log.Information($"RemoveBot: {callsign}");
+
+            if (_heartbeatTimer != null)
+            {
+                await _heartbeatTimer.DisposeAsync();
+                _heartbeatTimer = null;
+            }
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "RemoveBot failed for callsign {Callsign}", callsign);
-            throw new AtisBuilderException("RemoveBot action failed: " + ex.Message);
+            Log.Error(ex, $"RemoveBot Failed: {callsign}");
+            throw new AtisBuilderException("RemoveBot Failed: " + ex.Message);
+        }
+    }
+
+    private void HeartbeatTimerCallback(object? state)
+    {
+        if (state is string callsign)
+        {
+            SendHeartbeatAsync(callsign).SafeFireAndForget(onException: exception =>
+            {
+                Log.Error(exception, "SendHeartbeatAsync failed");
+            });
+        }
+    }
+
+    private async Task SendHeartbeatAsync(string callsign)
+    {
+        if (_jwtToken == null)
+            await Authenticate();
+
+        if (_jwtToken == null)
+            return;
+
+        try
+        {
+            await _downloader.GetAsync($"{VoiceServerUrl}/api/v1/bots/{callsign}/heartbeat", _jwtToken);
+            Log.Information($"Heartbeat: {callsign}");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"SendHeartbeatAsync failed for callsign {callsign}");
         }
     }
 
@@ -144,17 +185,17 @@ public class VoiceServerConnection : IVoiceServerConnection
 
     private void RefreshTokenCallback(object? state)
     {
-        _ = Task.Run(async () =>
+        try
         {
-            try
+            RefreshToken().SafeFireAndForget(onException: exception =>
             {
-                await RefreshToken();
-                Log.Debug("Voice server token refreshed.");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to refresh voice server token.");
-            }
-        });
+                Log.Error(exception, "RefreshToken Failed");
+            });
+            Log.Information("Voice server auth token refreshed.");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to refresh voice server auth token.");
+        }
     }
 }


### PR DESCRIPTION
Send heartbeat every 30 seconds, otherwise the voice server will disconnect the voice ATIS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a heartbeat mechanism to maintain active voice server connections, ensuring regular communication while a bot is active.
  - Added support for passing a JWT token when making GET, POST, PUT, and DELETE requests, enabling authorized access where required.

- **Improvements**
  - Enhanced error handling and logging for heartbeat and token refresh operations.
  - Improved consistency in log messages related to bot management actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->