### PR TITLE
Improve ATIS configuration change tracking

### DIFF
--- a/vATIS.Desktop/Events/DataGridCellEndEditEventArgEx.cs
+++ b/vATIS.Desktop/Events/DataGridCellEndEditEventArgEx.cs
@@ -1,0 +1,39 @@
+// <copyright file="DataGridCellEndEditEventArgEx.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using Avalonia.Controls;
+
+namespace Vatsim.Vatis.Events;
+
+/// <summary>
+/// Represents the event arguments for when a DataGrid cell editing ends.
+/// Contains the name of the DataGrid and the original event arguments from the cell edit ending.
+/// </summary>
+public class DataGridCellEndEditEventArgEx : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataGridCellEndEditEventArgEx"/> class.
+    /// </summary>
+    /// <param name="dataGridName">The name of the DataGrid associated with this event.</param>
+    /// <param name="args">The original <see cref="DataGridCellEditEndingEventArgs"/> passed from the DataGrid event.</param>
+    public DataGridCellEndEditEventArgEx(string dataGridName, DataGridCellEditEndingEventArgs args)
+    {
+        DataGridName = dataGridName;
+        Args = args;
+    }
+
+    /// <summary>
+    /// Gets the name of the DataGrid associated with the event.
+    /// This can be useful for identifying which DataGrid raised the event when handling multiple DataGrids.
+    /// </summary>
+    public string DataGridName { get; }
+
+    /// <summary>
+    /// Gets the original event arguments from the DataGrid's CellEditEnding event.
+    /// This contains information about the cell that was edited, such as the row, column, and the edit action.
+    /// </summary>
+    public DataGridCellEditEndingEventArgs Args { get; }
+}

--- a/vATIS.Desktop/Profiles/Models/CloudTypeMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/CloudTypeMeta.cs
@@ -3,6 +3,7 @@
 // Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using ReactiveUI;
 
 namespace Vatsim.Vatis.Profiles.Models;
@@ -10,4 +11,22 @@ namespace Vatsim.Vatis.Profiles.Models;
 /// <summary>
 /// Represents metadata for cloud types in the system, with acronym, spoken, and text values.
 /// </summary>
-public record CloudTypeMeta(string Acronym, string Spoken, string Text) : ReactiveRecord;
+public record CloudTypeMeta(string Acronym, string Spoken, string Text) : ReactiveRecord
+{
+    /// <inheritdoc />
+    public virtual bool Equals(CloudTypeMeta? other)
+    {
+        if (other != null)
+        {
+            return Acronym == other.Acronym && Spoken == other.Spoken && Text == other.Text;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Acronym, Spoken, Text);
+    }
+}

--- a/vATIS.Desktop/Profiles/Models/ConvectiveCloudTypeMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/ConvectiveCloudTypeMeta.cs
@@ -3,6 +3,7 @@
 // Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using ReactiveUI;
 
 namespace Vatsim.Vatis.Profiles.Models;
@@ -10,4 +11,22 @@ namespace Vatsim.Vatis.Profiles.Models;
 /// <summary>
 /// Represents metadata information for a convective cloud type, including a key and its corresponding value.
 /// </summary>
-public record ConvectiveCloudTypeMeta(string Key, string Value) : ReactiveRecord;
+public record ConvectiveCloudTypeMeta(string Key, string Value) : ReactiveRecord
+{
+    /// <inheritdoc />
+    public virtual bool Equals(ConvectiveCloudTypeMeta? other)
+    {
+        if (other != null)
+        {
+            return Key == other.Key && Value == other.Value;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Key, Value);
+    }
+}

--- a/vATIS.Desktop/Profiles/Models/PresentWeatherMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/PresentWeatherMeta.cs
@@ -3,6 +3,8 @@
 // Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using ReactiveUI;
 
 namespace Vatsim.Vatis.Profiles.Models;
@@ -10,4 +12,22 @@ namespace Vatsim.Vatis.Profiles.Models;
 /// <summary>
 /// Represents metadata information for current weather conditions in a structured format.
 /// </summary>
-public record PresentWeatherMeta(string Key, string Text, string Spoken) : ReactiveRecord;
+public record PresentWeatherMeta(string Key, string Text, string Spoken) : ReactiveRecord
+{
+    /// <inheritdoc />
+    public virtual bool Equals(PresentWeatherMeta? other)
+    {
+        if (other != null)
+        {
+            return Key == other.Key && Text == other.Text && Spoken == other.Spoken;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Key, Text, Spoken);
+    }
+}

--- a/vATIS.Desktop/Profiles/Models/TransitionLevelMeta.cs
+++ b/vATIS.Desktop/Profiles/Models/TransitionLevelMeta.cs
@@ -3,6 +3,7 @@
 // Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using ReactiveUI;
 
 namespace Vatsim.Vatis.Profiles.Models;
@@ -10,4 +11,22 @@ namespace Vatsim.Vatis.Profiles.Models;
 /// <summary>
 /// Represents metadata for a transition level, including the lower level, upper level, and altitude.
 /// </summary>
-public record TransitionLevelMeta(int Low, int High, int Altitude) : ReactiveRecord;
+public record TransitionLevelMeta(int Low, int High, int Altitude) : ReactiveRecord
+{
+    /// <inheritdoc />
+    public virtual bool Equals(TransitionLevelMeta? other)
+    {
+        if (other != null)
+        {
+            return Low == other.Low && High == other.High && Altitude == other.Altitude;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Low, High, Altitude);
+    }
+}

--- a/vATIS.Desktop/Ui/AtisConfiguration/ContractionsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/ContractionsView.axaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels.AtisConfiguration"
              xmlns:behaviors="using:Vatsim.Vatis.Ui.Behaviors"
-             xmlns:profiles="using:Vatsim.Vatis.Profiles"
              xmlns:models="clr-namespace:Vatsim.Vatis.Profiles.Models"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Vatsim.Vatis.Ui.AtisConfiguration.ContractionsView">

--- a/vATIS.Desktop/Ui/AtisConfiguration/ContractionsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/ContractionsView.axaml
@@ -11,7 +11,7 @@
 		<Border Background="#1E1E1E" BorderBrush="#646464" BorderThickness="1" CornerRadius="4" Padding="10">
 			<DataGrid Name="Contractions" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="380" ItemsSource="{Binding Contractions, DataType=vm:ContractionsViewModel}" SelectionMode="Extended" LoadingRow="Contractions_OnLoadingRow" CellEditEnding="Contractions_Validate">
 				<Interaction.Behaviors>
-					<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:ContractionsViewModel}"/>
+					<behaviors:DataGridCellEndEditBehavior DataGridName="Contractions" Command="{Binding CellEditEndingCommand, DataType=vm:ContractionsViewModel}"/>
 					<behaviors:DataGridTextUppercaseBehavior/>
 				</Interaction.Behaviors>
 				<DataGrid.Styles>

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -498,7 +498,7 @@
                             </Grid>
                             <DataGrid Name="WeatherDescriptors" MaxHeight="315" SelectionMode="Extended" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" ItemsSource="{Binding FilteredPresentWeatherTypes, DataType=vm:FormattingViewModel}">
 								<Interaction.Behaviors>
-									<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}"/>
+									<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}" DataGridName="PresentWeatherTypes"/>
 								</Interaction.Behaviors>
 								<DataGrid.Styles>
 									<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
@@ -557,7 +557,7 @@
 					<TabItem Header="Cloud Types">
 						<DataGrid GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" ItemsSource="{Binding CloudTypes, DataType=vm:FormattingViewModel}">
 							<Interaction.Behaviors>
-								<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}"/>
+								<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}" DataGridName="CloudTypes"/>
 							</Interaction.Behaviors>
 							<DataGrid.Styles>
 								<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
@@ -575,7 +575,7 @@
                         <StackPanel Orientation="Vertical" Spacing="10">
                             <DataGrid GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" ItemsSource="{Binding ConvectiveCloudTypes, DataType=vm:FormattingViewModel}">
 							    <Interaction.Behaviors>
-								    <behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}"/>
+								    <behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}" DataGridName="ConvectiveCloudTypes"/>
 							    </Interaction.Behaviors>
 							    <DataGrid.Styles>
 								    <Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
@@ -762,7 +762,7 @@
 						<StackPanel Orientation="Vertical" Spacing="10">
 							<DataGrid Name="TransitionLevels" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" ItemsSource="{Binding TransitionLevels, DataType=vm:FormattingViewModel}">
 								<Interaction.Behaviors>
-									<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}"/>
+									<behaviors:DataGridCellEndEditBehavior Command="{Binding CellEditEndingCommand, DataType=vm:FormattingViewModel}" DataGridName="TransitionLevels"/>
 								</Interaction.Behaviors>
 								<DataGrid.Styles>
 									<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">

--- a/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml
@@ -41,10 +41,11 @@
 			<CheckBox Name="UseExternalAtisGenerator" IsEnabled="{Binding #SelectedPreset.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" IsChecked="{Binding UseExternalAtisGenerator, DataType=vm:PresetsViewModel}" Theme="{StaticResource CheckBox}" Content="Use external ATIS generator (e.g. UniATIS)" />
 			<StackPanel Orientation="Vertical" Spacing="5" IsVisible="{Binding !#UseExternalAtisGenerator.IsChecked}">
 				<TextBlock Text="ATIS Template:"/>
-				<editor:TextEditor Name="AtisTemplate" FontFamily="{StaticResource Monospace}" Document="{Binding AtisTemplateTextDocument, DataType=vm:PresetsViewModel}" WordWrap="True" Height="300" IsEnabled="{Binding #SelectedPreset.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" Padding="8" TextChanged="AtisTemplate_OnTextChanged">
+				<editor:TextEditor Name="AtisTemplate" FontFamily="{StaticResource Monospace}" WordWrap="True" Height="300" IsEnabled="{Binding #SelectedPreset.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" Padding="8">
 					<Interaction.Behaviors>
 						<behaviors:TextEditorUpperCaseBehavior/>
 						<behaviors:TextEditorCompletionBehavior CompletionData="{Binding ContractionCompletionData, DataType=vm:PresetsViewModel}"/>
+                        <behaviors:DocumentTextBindingBehavior Text="{Binding AtisTemplateText, DataType=vm:PresetsViewModel, Mode=TwoWay}"/>
 					</Interaction.Behaviors>
 				</editor:TextEditor>
 				<WrapPanel Orientation="Horizontal" IsEnabled="{Binding #SelectedPreset.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}">

--- a/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
@@ -36,7 +36,7 @@ public partial class PresetsView : UserControl
             if (!AtisTemplate.TextArea.IsFocused)
                 return;
 
-            model.HasUnsavedChanges = true;
+            model.HasUnsavedChanges = ((AtisPreset)SelectedPreset.SelectedItem).Template != AtisTemplate.Text;
         }
     }
 

--- a/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/PresetsView.axaml.cs
@@ -29,17 +29,6 @@ public partial class PresetsView : UserControl
         InitializeComponent();
     }
 
-    private void AtisTemplate_OnTextChanged(object? sender, EventArgs e)
-    {
-        if (DataContext is PresetsViewModel model)
-        {
-            if (!AtisTemplate.TextArea.IsFocused)
-                return;
-
-            model.HasUnsavedChanges = ((AtisPreset)SelectedPreset.SelectedItem).Template != AtisTemplate.Text;
-        }
-    }
-
     private async void SelectedPreset_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         try

--- a/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/SandboxView.axaml.cs
@@ -138,7 +138,22 @@ public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
             if (!AirportConditions.TextArea.IsFocused)
                 return;
 
-            vm.HasUnsavedAirportConditions = true;
+            var readonlySegment = vm.ReadOnlyAirportConditions.FirstSegment;
+            string userText;
+
+            if (readonlySegment != null)
+            {
+                userText = readonlySegment.StartOffset == 0
+                    ? AirportConditions.Text[readonlySegment.EndOffset..].TrimEnd()
+                    : AirportConditions.Text[..readonlySegment.StartOffset].TrimEnd();
+            }
+            else
+            {
+                userText = AirportConditions.Text.TrimEnd();
+            }
+
+            var presetText = vm.SelectedPreset.AirportConditions?.TrimEnd() ?? "";
+            vm.HasUnsavedAirportConditions = !string.Equals(presetText, userText, StringComparison.OrdinalIgnoreCase);
         }
     }
 
@@ -152,7 +167,22 @@ public partial class SandboxView : ReactiveUserControl<SandboxViewModel>
             if (!NotamFreeText.TextArea.IsFocused)
                 return;
 
-            vm.HasUnsavedNotams = true;
+            var readonlySegment = vm.ReadOnlyNotams.FirstSegment;
+            string userText;
+
+            if (readonlySegment != null)
+            {
+                userText = readonlySegment.StartOffset == 0
+                    ? NotamFreeText.Text[readonlySegment.EndOffset..].TrimEnd()
+                    : NotamFreeText.Text[..readonlySegment.StartOffset].TrimEnd();
+            }
+            else
+            {
+                userText = NotamFreeText.Text.TrimEnd();
+            }
+
+            var presetText = vm.SelectedPreset.Notams?.TrimEnd() ?? "";
+            vm.HasUnsavedNotams = !string.Equals(presetText, userText, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/vATIS.Desktop/Ui/Behaviors/DataGridCellEndEditBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/DataGridCellEndEditBehavior.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Xaml.Interactivity;
+using Vatsim.Vatis.Events;
 
 namespace Vatsim.Vatis.Ui.Behaviors;
 
@@ -23,12 +24,27 @@ public class DataGridCellEndEditBehavior : Behavior<DataGrid>
         AvaloniaProperty.Register<DataGridCellEndEditBehavior, ICommand?>(nameof(Command));
 
     /// <summary>
+    /// Identifies the name of the DataGrid from which this command is executed from.
+    /// </summary>
+    public static readonly StyledProperty<string> DataGridNameProperty =
+        AvaloniaProperty.Register<DataGridCellEndEditBehavior, string>(nameof(DataGridName));
+
+    /// <summary>
     /// Gets or sets the command to be executed when cell editing ends in a DataGrid control.
     /// </summary>
     public ICommand? Command
     {
         get => GetValue(CommandProperty);
         set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the DataGrid.
+    /// </summary>
+    public string DataGridName
+    {
+        get => GetValue(DataGridNameProperty);
+        set => SetValue(DataGridNameProperty, value);
     }
 
     /// <inheritdoc/>
@@ -55,6 +71,7 @@ public class DataGridCellEndEditBehavior : Behavior<DataGrid>
 
     private void AssociatedObjectOnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
     {
-        Command?.Execute(e);
+        var args = new DataGridCellEndEditEventArgEx(DataGridName, e);
+        Command?.Execute(args);
     }
 }

--- a/vATIS.Desktop/Ui/Behaviors/DocumentTextBindingBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/DocumentTextBindingBehavior.cs
@@ -1,0 +1,82 @@
+// <copyright file="DocumentTextBindingBehavior.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using Avalonia;
+using Avalonia.Xaml.Interactivity;
+using AvaloniaEdit;
+
+namespace Vatsim.Vatis.Ui.Behaviors;
+
+/// <summary>
+/// Behavior that binds the text content of a <see cref="TextEditor"/> to a dependency property.
+/// </summary>
+public class DocumentTextBindingBehavior : Behavior<TextEditor>
+{
+    /// <summary>
+    /// Defines the Text dependency property for binding the text content.
+    /// </summary>
+    public static readonly StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<DocumentTextBindingBehavior, string>(nameof(Text));
+
+    private TextEditor? _textEditor;
+
+    /// <summary>
+    /// Gets or sets the text content of the associated <see cref="TextEditor"/>.
+    /// </summary>
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        if (AssociatedObject is { } textEditor)
+        {
+            _textEditor = textEditor;
+            _textEditor.TextChanged += OnTextChanged;
+            this.GetObservable(TextProperty).Subscribe(TextPropertyChanged);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+
+        if (_textEditor != null)
+        {
+            _textEditor.TextChanged -= OnTextChanged;
+        }
+    }
+
+    private void OnTextChanged(object? sender, EventArgs e)
+    {
+        if (_textEditor is { Document: not null })
+        {
+            Text = _textEditor.Document.Text;
+        }
+    }
+
+    private void TextPropertyChanged(string? text)
+    {
+        if (_textEditor is { Document: not null })
+        {
+            text ??= string.Empty;
+
+            var caretOffset = _textEditor.CaretOffset;
+
+            if (_textEditor.Document.Text != text)
+            {
+                _textEditor.Document.Text = text;
+                _textEditor.CaretOffset = Math.Min(caretOffset, text.Length);
+            }
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/Common/ChangeTracker.cs
+++ b/vATIS.Desktop/Ui/Common/ChangeTracker.cs
@@ -1,0 +1,127 @@
+// <copyright file="ChangeTracker.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using ReactiveUI;
+
+namespace Vatsim.Vatis.Ui.Common;
+
+/// <summary>
+/// Provides functionality to track changes to property values and determine if unsaved changes exist.
+/// </summary>
+public class ChangeTracker : ReactiveObject
+{
+    private readonly Dictionary<string, (object? OriginalValue, object? CurrentValue)> _fieldHistory = [];
+    private readonly BehaviorSubject<bool> _hasUnsavedChangesSubject = new(false);
+    private bool _hasUnsavedChanges;
+
+    /// <summary>
+    /// Gets an observable stream that emits the current status of unsaved changes.
+    /// </summary>
+    /// <remarks>
+    /// Subscribers will receive updates whenever there is a change to the tracked properties
+    /// and whether any changes have been made that are not yet saved.
+    /// </remarks>
+    public IObservable<bool> HasUnsavedChangesObservable => _hasUnsavedChangesSubject.AsObservable();
+
+    private bool HasUnsavedChanges
+    {
+        get => _hasUnsavedChanges;
+        set => this.RaiseAndSetIfChanged(ref _hasUnsavedChanges, value);
+    }
+
+    /// <summary>
+    /// Applies any unsaved changes by marking current values as the new original values,
+    /// and resets the <see cref="HasUnsavedChanges"/> flag.
+    /// </summary>
+    /// <returns><c>true</c> if any changes were applied; otherwise, <c>false</c>.</returns>
+    public bool ApplyChangesIfNeeded()
+    {
+        if (!HasUnsavedChanges)
+            return false;
+
+        foreach (var key in _fieldHistory.Keys.ToList())
+        {
+            var (_, currentValue) = _fieldHistory[key];
+            _fieldHistory[key] = (currentValue, currentValue);
+        }
+
+        HasUnsavedChanges = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Tracks a property change by comparing the current value to the original.
+    /// </summary>
+    /// <param name="propertyName">The name of the property being tracked.</param>
+    /// <param name="currentValue">The current value of the property.</param>
+    public void TrackChange(string propertyName, object? currentValue)
+    {
+        if (_fieldHistory.TryGetValue(propertyName, out var value))
+        {
+            var (originalValue, _) = value;
+            _fieldHistory[propertyName] = (originalValue, currentValue);
+        }
+        else
+        {
+            _fieldHistory[propertyName] = (currentValue, currentValue);
+        }
+
+        CheckForUnsavedChanges();
+    }
+
+    /// <summary>
+    /// Resets all tracked changes and clears the change history.
+    /// </summary>
+    public void ResetChanges()
+    {
+        _fieldHistory.Clear();
+        HasUnsavedChanges = false;
+    }
+
+    /// <summary>
+    /// Compares two values to determine if they are equal.
+    /// </summary>
+    /// <param name="originalValue">The original value of the property.</param>
+    /// <param name="currentValue">The current value of the property.</param>
+    /// <returns><c>true</c> if the values are equal; otherwise, <c>false</c>.</returns>
+    private static bool AreValuesEqual(object? originalValue, object? currentValue)
+    {
+        if (originalValue == null && currentValue == null)
+            return true;
+
+        if (originalValue == null || currentValue == null)
+            return false;
+
+        if (originalValue is string s1 && currentValue is string s2)
+            return s1 == s2;
+
+        if (originalValue is int i1 && currentValue is int i2)
+            return i1 == i2;
+
+        if (originalValue is bool b1 && currentValue is bool b2)
+            return b1 == b2;
+
+        if (originalValue is IEnumerable<object> e1 && currentValue is IEnumerable<object> e2)
+            return e1.SequenceEqual(e2);
+
+        return originalValue.Equals(currentValue);
+    }
+
+    /// <summary>
+    /// Checks if there are any changes between original and current values.
+    /// </summary>
+    private void CheckForUnsavedChanges()
+    {
+        HasUnsavedChanges = _fieldHistory.Any(entry =>
+            !AreValuesEqual(entry.Value.OriginalValue, entry.Value.CurrentValue));
+
+        _hasUnsavedChangesSubject.OnNext(HasUnsavedChanges);
+    }
+}

--- a/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/NewAtisStationDialog.axaml
@@ -3,8 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:converters="using:Vatsim.Vatis.Ui.Converters"
-		xmlns:profiles="using:Vatsim.Vatis.Profiles"
-		xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
+        xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels"
 		xmlns:behaviors="using:Vatsim.Vatis.Ui.Behaviors"
 		xmlns:models="clr-namespace:Vatsim.Vatis.Profiles.Models"
 		mc:Ignorable="d"
@@ -80,6 +79,15 @@
 						</Interaction.Behaviors>
 					</TextBox>
 				</StackPanel>
+                <StackPanel Spacing="5">
+                    <TextBlock Text="Frequency:"/>
+                    <TextBox Name="Frequency" Text="{Binding Frequency, DataType=vm:NewAtisStationDialogViewModel}" Theme="{StaticResource DarkTextBox}">
+                        <Interaction.Behaviors>
+                            <behaviors:VhfFrequencyFormatBehavior/>
+                            <behaviors:SelectAllTextOnFocusBehavior/>
+                        </Interaction.Behaviors>
+                    </TextBox>
+                </StackPanel>
 				<StackPanel Spacing="5">
 					<TextBlock Text="ATIS Type:"/>
 					<StackPanel Orientation="Horizontal" Spacing="15">

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/ContractionsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/ContractionsViewModel.cs
@@ -47,7 +47,7 @@ public class ContractionsViewModel : ReactiveViewModelBase, IDisposable
         _appConfig = appConfig;
 
         AtisStationChanged = ReactiveCommand.Create<AtisStation>(HandleAtisStationChanged);
-        CellEditEndingCommand = ReactiveCommand.Create<DataGridCellEditEndingEventArgs>(HandleCellEditEnding);
+        CellEditEndingCommand = ReactiveCommand.Create<DataGridCellEndEditEventArgEx>(HandleCellEditEnding);
         NewContractionCommand = ReactiveCommand.CreateFromTask(HandleNewContraction);
         DeleteContractionCommand = ReactiveCommand.CreateFromTask<ContractionMeta>(HandleDeleteContraction);
 
@@ -70,7 +70,7 @@ public class ContractionsViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets the command executed when a cell edit operation is ending in the data grid.
     /// </summary>
-    public ReactiveCommand<DataGridCellEditEndingEventArgs, Unit> CellEditEndingCommand { get; }
+    public ReactiveCommand<DataGridCellEndEditEventArgEx, Unit> CellEditEndingCommand { get; }
 
     /// <summary>
     /// Gets the command used to add a new contraction.
@@ -245,11 +245,14 @@ public class ContractionsViewModel : ReactiveViewModelBase, IDisposable
         }
     }
 
-    private void HandleCellEditEnding(DataGridCellEditEndingEventArgs e)
+    private void HandleCellEditEnding(DataGridCellEndEditEventArgEx e)
     {
-        if (e.EditAction == DataGridEditAction.Commit)
+        if (SelectedStation == null)
+            return;
+
+        if (e.Args.EditAction == DataGridEditAction.Commit)
         {
-            HasUnsavedChanges = true;
+            EventBus.Instance.Publish(new ContractionsUpdated(SelectedStation.Id));
         }
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.Editing;
 using ReactiveUI;
 using Vatsim.Vatis.Events;
@@ -24,7 +23,6 @@ using Vatsim.Vatis.Sessions;
 using Vatsim.Vatis.Ui.Controls;
 using Vatsim.Vatis.Ui.Dialogs;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
-using Vatsim.Vatis.Ui.Models;
 
 namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 
@@ -110,7 +108,6 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private ObservableCollection<PresentWeatherMeta>? _presentWeatherTypes;
     private ObservableCollection<CloudTypeMeta>? _cloudTypes;
     private ObservableCollection<ConvectiveCloudTypeMeta>? _convectiveCloudTypes;
-    private List<ICompletionData> _contractionCompletionData = new();
     private string _presentWeatherSearchTerm = string.Empty;
     private ObservableCollection<PresentWeatherMeta>? _filteredPresentWeatherTypes;
     private bool _presentWeatherFilterAcronym = true;
@@ -1145,15 +1142,6 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref _convectiveCloudTypes, value);
     }
 
-    /// <summary>
-    /// Gets or sets the contraction completion data.
-    /// </summary>
-    public List<ICompletionData> ContractionCompletionData
-    {
-        get => _contractionCompletionData;
-        set => this.RaiseAndSetIfChanged(ref _contractionCompletionData, value);
-    }
-
     /// <inheritdoc />
     public void Dispose()
     {
@@ -1759,15 +1747,6 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         // Track initial TransitionLevels.
         TrackChanges(nameof(TransitionLevels), TransitionLevels?.Select(item =>
             new TransitionLevelMeta(item.Low, item.High, item.Altitude)).ToList());
-
-        ContractionCompletionData = [];
-        foreach (var contraction in station.Contractions)
-        {
-            if (!string.IsNullOrEmpty(contraction.VariableName) && !string.IsNullOrEmpty(contraction.Voice))
-            {
-                ContractionCompletionData.Add(new AutoCompletionData(contraction.VariableName, contraction.Voice));
-            }
-        }
 
         if (PresentWeatherTypes != null)
         {

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -16,6 +16,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.Editing;
 using ReactiveUI;
+using Vatsim.Vatis.Events;
 using Vatsim.Vatis.Profiles;
 using Vatsim.Vatis.Profiles.AtisFormat.Nodes;
 using Vatsim.Vatis.Profiles.Models;
@@ -33,10 +34,10 @@ namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 public class FormattingViewModel : ReactiveViewModelBase, IDisposable
 {
     private readonly CompositeDisposable _disposables = [];
-    private readonly HashSet<string> _initializedProperties = [];
     private readonly IProfileRepository _profileRepository;
     private readonly ISessionManager _sessionManager;
     private readonly IWindowFactory _windowFactory;
+    private readonly Dictionary<string, (object? OriginalValue, object? CurrentValue)> _fieldHistory;
     private ObservableCollection<string>? _formattingOptions;
     private AtisStation? _selectedStation;
     private bool _hasUnsavedChanges;
@@ -131,11 +132,13 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         _profileRepository = profileRepository;
         _sessionManager = sessionManager;
 
+        _fieldHistory = [];
+
         FormattingOptions = [];
 
         AtisStationChanged = ReactiveCommand.Create<AtisStation>(HandleAtisStationChanged);
         TemplateVariableClicked = ReactiveCommand.Create<string>(HandleTemplateVariableClicked);
-        CellEditEndingCommand = ReactiveCommand.Create<DataGridCellEditEndingEventArgs>(HandleCellEditEnding);
+        CellEditEndingCommand = ReactiveCommand.Create<DataGridCellEndEditEventArgEx>(HandleCellEditEnding);
         AddTransitionLevelCommand = ReactiveCommand.CreateFromTask(HandleAddTransitionLevel);
         DeleteTransitionLevelCommand =
             ReactiveCommand.CreateFromTask<TransitionLevelMeta>(HandleDeleteTransitionLevel);
@@ -165,7 +168,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets the command executed when cell editing ends in a data grid.
     /// </summary>
-    public ReactiveCommand<DataGridCellEditEndingEventArgs, Unit> CellEditEndingCommand { get; }
+    public ReactiveCommand<DataGridCellEndEditEventArgEx, Unit> CellEditEndingCommand { get; }
 
     /// <summary>
     /// Gets the command used to add a transition level in the view model.
@@ -222,10 +225,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _routineObservationTime, value);
-            if (!_initializedProperties.Add(nameof(RoutineObservationTime)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(RoutineObservationTime), value);
         }
     }
 
@@ -238,10 +238,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _observationTimeTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(ObservationTimeTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(ObservationTimeTextTemplate), value);
         }
     }
 
@@ -254,10 +251,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _observationTimeVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(ObservationTimeVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(ObservationTimeVoiceTemplate), value);
         }
     }
 
@@ -270,10 +264,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _speakWindSpeedLeadingZero, value);
-            if (!_initializedProperties.Add(nameof(SpeakWindSpeedLeadingZero)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(SpeakWindSpeedLeadingZero), value);
         }
     }
 
@@ -286,10 +277,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _magneticVariationEnabled, value);
-            if (!_initializedProperties.Add(nameof(MagneticVariationEnabled)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(MagneticVariationEnabled), value);
         }
     }
 
@@ -302,10 +290,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _magneticVariationValue, value);
-            if (!_initializedProperties.Add(nameof(MagneticVariationValue)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(MagneticVariationValue), value);
         }
     }
 
@@ -318,10 +303,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(StandardWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(StandardWindTextTemplate), value);
         }
     }
 
@@ -334,10 +316,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(StandardWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(StandardWindVoiceTemplate), value);
         }
     }
 
@@ -350,10 +329,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardGustWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(StandardGustWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(StandardGustWindTextTemplate), value);
         }
     }
 
@@ -366,10 +342,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardGustWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(StandardGustWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(StandardGustWindVoiceTemplate), value);
         }
     }
 
@@ -382,10 +355,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableWindTextTemplate), value);
         }
     }
 
@@ -398,10 +368,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableWindVoiceTemplate), value);
         }
     }
 
@@ -414,10 +381,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableGustWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableGustWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableGustWindTextTemplate), value);
         }
     }
 
@@ -430,10 +394,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableGustWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableGustWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableGustWindVoiceTemplate), value);
         }
     }
 
@@ -446,10 +407,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableDirectionWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableDirectionWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableDirectionWindTextTemplate), value);
         }
     }
 
@@ -462,10 +420,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableDirectionWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(VariableDirectionWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VariableDirectionWindVoiceTemplate), value);
         }
     }
 
@@ -478,10 +433,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(CalmWindTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CalmWindTextTemplate), value);
         }
     }
 
@@ -494,10 +446,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(CalmWindVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CalmWindVoiceTemplate), value);
         }
     }
 
@@ -510,10 +459,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindSpeed, value);
-            if (!_initializedProperties.Add(nameof(CalmWindSpeed)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CalmWindSpeed), value);
         }
     }
 
@@ -526,10 +472,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(VisibilityTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityTextTemplate), value);
         }
     }
 
@@ -542,10 +485,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(VisibilityVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityVoiceTemplate), value);
         }
     }
 
@@ -558,10 +498,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _presentWeatherTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(PresentWeatherTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(PresentWeatherTextTemplate), value);
         }
     }
 
@@ -574,10 +511,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _presentWeatherVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(PresentWeatherVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(PresentWeatherVoiceTemplate), value);
         }
     }
 
@@ -590,10 +524,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _recentWeatherTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(RecentWeatherTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(RecentWeatherTextTemplate), value);
         }
     }
 
@@ -606,10 +537,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _recentWeatherVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(RecentWeatherVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(RecentWeatherVoiceTemplate), value);
         }
     }
 
@@ -622,10 +550,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(CloudsTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CloudsTextTemplate), value);
         }
     }
 
@@ -638,10 +563,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(CloudsVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CloudsVoiceTemplate), value);
         }
     }
 
@@ -654,10 +576,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(TemperatureTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TemperatureTextTemplate), value);
         }
     }
 
@@ -670,10 +589,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(TemperatureVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TemperatureVoiceTemplate), value);
         }
     }
 
@@ -686,10 +602,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(DewpointTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(DewpointTextTemplate), value);
         }
     }
 
@@ -702,10 +615,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(DewpointVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(DewpointVoiceTemplate), value);
         }
     }
 
@@ -718,10 +628,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(AltimeterTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(AltimeterTextTemplate), value);
         }
     }
 
@@ -734,10 +641,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(AltimeterVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(AltimeterVoiceTemplate), value);
         }
     }
 
@@ -750,10 +654,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(ClosingStatementTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(ClosingStatementTextTemplate), value);
         }
     }
 
@@ -766,10 +667,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(ClosingStatementVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(ClosingStatementVoiceTemplate), value);
         }
     }
 
@@ -782,10 +680,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _notamsTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(NotamsTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(NotamsTextTemplate), value);
         }
     }
 
@@ -798,10 +693,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _notamsVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(NotamsVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(NotamsVoiceTemplate), value);
         }
     }
 
@@ -814,10 +706,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorth, value);
-            if (!_initializedProperties.Add(nameof(VisibilityNorth)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityNorth), value);
         }
     }
 
@@ -830,10 +719,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorthEast, value);
-            if (!_initializedProperties.Add(nameof(VisibilityNorthEast)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityNorthEast), value);
         }
     }
 
@@ -846,10 +732,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityEast, value);
-            if (!_initializedProperties.Add(nameof(VisibilityEast)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityEast), value);
         }
     }
 
@@ -862,10 +745,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouthEast, value);
-            if (!_initializedProperties.Add(nameof(VisibilitySouthEast)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilitySouthEast), value);
         }
     }
 
@@ -878,10 +758,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouth, value);
-            if (!_initializedProperties.Add(nameof(VisibilitySouth)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilitySouth), value);
         }
     }
 
@@ -894,10 +771,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouthWest, value);
-            if (!_initializedProperties.Add(nameof(VisibilitySouthWest)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilitySouthWest), value);
         }
     }
 
@@ -910,10 +784,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityWest, value);
-            if (!_initializedProperties.Add(nameof(VisibilityWest)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityWest), value);
         }
     }
 
@@ -926,10 +797,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorthWest, value);
-            if (!_initializedProperties.Add(nameof(VisibilityNorthWest)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityNorthWest), value);
         }
     }
 
@@ -942,10 +810,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityUnlimitedVisibilityVoice, value);
-            if (!_initializedProperties.Add(nameof(VisibilityUnlimitedVisibilityVoice)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityUnlimitedVisibilityVoice), value);
         }
     }
 
@@ -958,10 +823,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityUnlimitedVisibilityText, value);
-            if (!_initializedProperties.Add(nameof(VisibilityUnlimitedVisibilityText)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityUnlimitedVisibilityText), value);
         }
     }
 
@@ -974,10 +836,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityIncludeVisibilitySuffix, value);
-            if (!_initializedProperties.Add(nameof(VisibilityIncludeVisibilitySuffix)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityIncludeVisibilitySuffix), value);
         }
     }
 
@@ -990,10 +849,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityMetersCutoff, value);
-            if (!_initializedProperties.Add(nameof(VisibilityMetersCutoff)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(VisibilityMetersCutoff), value);
         }
     }
 
@@ -1006,10 +862,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsIdentifyCeilingLayer, value);
-            if (!_initializedProperties.Add(nameof(CloudsIdentifyCeilingLayer)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CloudsIdentifyCeilingLayer), value);
         }
     }
 
@@ -1022,10 +875,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsConvertToMetric, value);
-            if (!_initializedProperties.Add(nameof(CloudsConvertToMetric)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CloudsConvertToMetric), value);
         }
     }
 
@@ -1038,10 +888,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _undeterminedLayerAltitudeText, value);
-            if (!_initializedProperties.Add(nameof(UndeterminedLayerAltitudeText)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(UndeterminedLayerAltitudeText), value);
         }
     }
 
@@ -1054,10 +901,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _undeterminedLayerAltitudeVoice, value);
-            if (!_initializedProperties.Add(nameof(UndeterminedLayerAltitudeVoice)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(UndeterminedLayerAltitudeVoice), value);
         }
     }
 
@@ -1070,10 +914,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _automaticCbDetectionText, value);
-            if (!_initializedProperties.Add(nameof(AutomaticCbDetectionText)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(AutomaticCbDetectionText), value);
         }
     }
 
@@ -1086,10 +927,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _automaticCbDetectionVoice, value);
-            if (!_initializedProperties.Add(nameof(AutomaticCbDetectionVoice)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(AutomaticCbDetectionVoice), value);
         }
     }
 
@@ -1102,10 +940,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudHeightAltitudeInHundreds, value);
-            if (!_initializedProperties.Add(nameof(CloudHeightAltitudeInHundreds)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(CloudHeightAltitudeInHundreds), value);
         }
     }
 
@@ -1118,10 +953,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureUsePlusPrefix, value);
-            if (!_initializedProperties.Add(nameof(TemperatureUsePlusPrefix)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TemperatureUsePlusPrefix), value);
         }
     }
 
@@ -1134,10 +966,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureSpeakLeadingZero, value);
-            if (!_initializedProperties.Add(nameof(TemperatureSpeakLeadingZero)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TemperatureSpeakLeadingZero), value);
         }
     }
 
@@ -1150,10 +979,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointUsePlusPrefix, value);
-            if (!_initializedProperties.Add(nameof(DewpointUsePlusPrefix)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(DewpointUsePlusPrefix), value);
         }
     }
 
@@ -1166,10 +992,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointSpeakLeadingZero, value);
-            if (!_initializedProperties.Add(nameof(DewpointSpeakLeadingZero)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(DewpointSpeakLeadingZero), value);
         }
     }
 
@@ -1182,10 +1005,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterSpeakDecimal, value);
-            if (!_initializedProperties.Add(nameof(AltimeterSpeakDecimal)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(AltimeterSpeakDecimal), value);
         }
     }
 
@@ -1198,10 +1018,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementAutoIncludeClosingStatement, value);
-            if (!_initializedProperties.Add(nameof(ClosingStatementAutoIncludeClosingStatement)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(ClosingStatementAutoIncludeClosingStatement), value);
         }
     }
 
@@ -1211,14 +1028,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     public ObservableCollection<TransitionLevelMeta>? TransitionLevels
     {
         get => _transitionLevelMetas;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref _transitionLevelMetas, value);
-            if (!_initializedProperties.Add(nameof(TransitionLevels)))
-            {
-                HasUnsavedChanges = true;
-            }
-        }
+        set => this.RaiseAndSetIfChanged(ref _transitionLevelMetas, value);
     }
 
     /// <summary>
@@ -1230,10 +1040,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _transitionLevelTextTemplate, value);
-            if (!_initializedProperties.Add(nameof(TransitionLevelTextTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TransitionLevelTextTemplate), value);
         }
     }
 
@@ -1246,10 +1053,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _transitionLevelVoiceTemplate, value);
-            if (!_initializedProperties.Add(nameof(TransitionLevelVoiceTemplate)))
-            {
-                HasUnsavedChanges = true;
-            }
+            TrackChanges(nameof(TransitionLevelVoiceTemplate), value);
         }
     }
 
@@ -1365,7 +1169,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     {
         if (SelectedStation == null)
         {
-            return true;
+            return false;
         }
 
         ClearAllErrors();
@@ -1784,7 +1588,23 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
-        HasUnsavedChanges = false;
+        // Check if there are unsaved changes before saving
+        var anyChanges = _fieldHistory.Any(entry => !AreValuesEqual(entry.Value.OriginalValue, entry.Value.CurrentValue));
+
+        // If there are unsaved changes, mark as applied and reset HasUnsavedChanges
+        if (anyChanges)
+        {
+            // Apply changes and reset HasUnsavedChanges
+            foreach (var key in _fieldHistory.Keys.ToList())
+            {
+                var (_, currentValue) = _fieldHistory[key];
+
+                // After applying changes, set the original value to the current value (the saved value)
+                _fieldHistory[key] = (currentValue, currentValue);
+            }
+
+            HasUnsavedChanges = false;
+        }
 
         return true;
     }
@@ -1898,10 +1718,14 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             station.AtisFormat.ClosingStatement.AutoIncludeClosingStatement;
 
         PresentWeatherTypes = [];
-        foreach (var kvp in station.AtisFormat.PresentWeather.PresentWeatherTypes)
+        foreach (var kvp in station.AtisFormat.PresentWeather.PresentWeatherTypes.OrderBy(n => n.Key))
         {
             PresentWeatherTypes.Add(new PresentWeatherMeta(kvp.Key, kvp.Value.Text, kvp.Value.Spoken));
         }
+
+        // Track initial PresentWeatherTypes.
+        TrackChanges(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
+            new PresentWeatherMeta(item.Key, item.Text, item.Spoken)).ToList());
 
         CloudTypes = [];
         foreach (var item in station.AtisFormat.Clouds.Types)
@@ -1909,11 +1733,19 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             CloudTypes.Add(new CloudTypeMeta(item.Key, item.Value.Voice, item.Value.Text));
         }
 
+        // Track initial CloudTypes.
+        TrackChanges(nameof(CloudTypes), CloudTypes?.Select(item =>
+            new CloudTypeMeta(item.Acronym, item.Spoken, item.Text)).ToList());
+
         ConvectiveCloudTypes = [];
         foreach (var item in station.AtisFormat.Clouds.ConvectiveTypes)
         {
             ConvectiveCloudTypes.Add(new ConvectiveCloudTypeMeta(item.Key, item.Value));
         }
+
+        // Track initial ConvectiveCloudTypes.
+        TrackChanges(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
+            new ConvectiveCloudTypeMeta(item.Key, item.Value)).ToList());
 
         TransitionLevelTextTemplate = station.AtisFormat.TransitionLevel.Template.Text;
         TransitionLevelVoiceTemplate = station.AtisFormat.TransitionLevel.Template.Voice;
@@ -1923,6 +1755,10 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         {
             TransitionLevels.Add(item);
         }
+
+        // Track initial TransitionLevels.
+        TrackChanges(nameof(TransitionLevels), TransitionLevels?.Select(item =>
+            new TransitionLevelMeta(item.Low, item.High, item.Altitude)).ToList());
 
         ContractionCompletionData = [];
         foreach (var contraction in station.Contractions)
@@ -2055,11 +1891,29 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         }
     }
 
-    private void HandleCellEditEnding(DataGridCellEditEndingEventArgs e)
+    private void HandleCellEditEnding(DataGridCellEndEditEventArgEx e)
     {
-        if (e.EditAction == DataGridEditAction.Commit)
+        if (e.Args.EditAction == DataGridEditAction.Commit)
         {
-            HasUnsavedChanges = true;
+            switch (e.DataGridName)
+            {
+                case nameof(PresentWeatherTypes):
+                    TrackChanges(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
+                        new PresentWeatherMeta(item.Key, item.Text, item.Spoken)).ToList());
+                    break;
+                case nameof(CloudTypes):
+                    TrackChanges(nameof(CloudTypes), CloudTypes?.Select(item =>
+                        new CloudTypeMeta(item.Acronym, item.Spoken, item.Text)).ToList());
+                    break;
+                case nameof(ConvectiveCloudTypes):
+                    TrackChanges(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
+                        new ConvectiveCloudTypeMeta(item.Key, item.Value)).ToList());
+                    break;
+                case nameof(TransitionLevels):
+                    TrackChanges(nameof(TransitionLevels), TransitionLevels?.Select(item =>
+                        new TransitionLevelMeta(item.Low, item.High, item.Altitude)).ToList());
+                    break;
+            }
         }
     }
 
@@ -2114,5 +1968,76 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         return (PresentWeatherFilterAcronym && weather.Key.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase)) ||
                (PresentWeatherFilterText && weather.Text.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase)) ||
                (PresentWeatherFilterSpoken && weather.Spoken.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private void TrackChanges(string propertyName, object? currentValue)
+    {
+        if (_fieldHistory.TryGetValue(propertyName, out var value))
+        {
+            var (originalValue, _) = value;
+
+            // If the property has been set before, update the current value
+            _fieldHistory[propertyName] = (originalValue, currentValue);
+
+            // Check for unsaved changes after the update
+            CheckForUnsavedChanges();
+        }
+        else
+        {
+            // If this is the first time setting the value, initialize the original value
+            _fieldHistory[propertyName] = (currentValue, currentValue);
+
+            // Check for unsaved changes after the update
+            CheckForUnsavedChanges();
+        }
+    }
+
+    private bool AreValuesEqual(object? originalValue, object? currentValue)
+    {
+        // If both are null, consider them equal
+        if (originalValue == null && currentValue == null)
+            return true;
+
+        // If one is null and the other is not, they are not equal
+        if (originalValue == null || currentValue == null)
+            return false;
+
+        // Handle comparison for nullable types like int?, string?, bool? etc.
+        if (originalValue is string originalStr && currentValue is string currentStr)
+        {
+            return originalStr == currentStr;
+        }
+
+        // Compare nullable int (int?)
+        if (originalValue is int originalInt && currentValue is int currentInt)
+        {
+            return originalInt == currentInt;
+        }
+
+        // Compare nullable bool (bool?)
+        if (originalValue is bool originalBool && currentValue is bool currentBool)
+        {
+            return originalBool == currentBool;
+        }
+
+        if (originalValue is IEnumerable<object> originalEnumerable &&
+            currentValue is IEnumerable<object> currentEnumerable)
+        {
+            return AreListsEqual(originalEnumerable, currentEnumerable);
+        }
+
+        // For non-nullable types (or if types are not specifically handled above), use Equals
+        return originalValue.Equals(currentValue);
+    }
+
+    private bool AreListsEqual(IEnumerable<object> list1, IEnumerable<object> list2)
+    {
+        return list1.SequenceEqual(list2);
+    }
+
+    private void CheckForUnsavedChanges()
+    {
+        var anyChanges = _fieldHistory.Any(entry => !AreValuesEqual(entry.Value.OriginalValue, entry.Value.CurrentValue));
+        HasUnsavedChanges = anyChanges;
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -1154,14 +1154,14 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    /// <summary>
-    /// Applies pending, unsaved changes.
-    /// </summary>
+    /// <summary>Applies pending, unsaved changes.</summary>
+    /// <param name="hasErrors">A value indicating whether there are errors.</param>
     /// <returns>A value indicating whether changes are applied.</returns>
-    public bool ApplyChanges()
+    public bool ApplyChanges(out bool hasErrors)
     {
         if (SelectedStation == null)
         {
+            hasErrors = false;
             return false;
         }
 
@@ -1176,17 +1176,16 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
                 {
                     if (value < 0 || value > 59)
                     {
-                        RaiseError(
-                            nameof(RoutineObservationTime),
+                        RaiseError(nameof(RoutineObservationTime),
                             "Invalid routine observation time. Time values must between 0 and 59.");
+                        hasErrors = true;
                         return false;
                     }
 
                     if (observationTimes.Contains(value))
                     {
-                        RaiseError(
-                            nameof(RoutineObservationTime),
-                            "Duplicate routine observation time values.");
+                        RaiseError(nameof(RoutineObservationTime), "Duplicate routine observation time values.");
+                        hasErrors = true;
                         return false;
                     }
 
@@ -1573,6 +1572,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
 
         if (HasErrors)
         {
+            hasErrors = true;
             return false;
         }
 
@@ -1581,6 +1581,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
+        hasErrors = false;
         return _changeTracker.ApplyChangesIfNeeded();
     }
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -20,6 +21,7 @@ using Vatsim.Vatis.Profiles;
 using Vatsim.Vatis.Profiles.AtisFormat.Nodes;
 using Vatsim.Vatis.Profiles.Models;
 using Vatsim.Vatis.Sessions;
+using Vatsim.Vatis.Ui.Common;
 using Vatsim.Vatis.Ui.Controls;
 using Vatsim.Vatis.Ui.Dialogs;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
@@ -35,7 +37,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private readonly IProfileRepository _profileRepository;
     private readonly ISessionManager _sessionManager;
     private readonly IWindowFactory _windowFactory;
-    private readonly Dictionary<string, (object? OriginalValue, object? CurrentValue)> _fieldHistory;
+    private readonly ChangeTracker _changeTracker = new();
     private ObservableCollection<string>? _formattingOptions;
     private AtisStation? _selectedStation;
     private bool _hasUnsavedChanges;
@@ -129,8 +131,6 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         _profileRepository = profileRepository;
         _sessionManager = sessionManager;
 
-        _fieldHistory = [];
-
         FormattingOptions = [];
 
         AtisStationChanged = ReactiveCommand.Create<AtisStation>(HandleAtisStationChanged);
@@ -139,6 +139,11 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         AddTransitionLevelCommand = ReactiveCommand.CreateFromTask(HandleAddTransitionLevel);
         DeleteTransitionLevelCommand =
             ReactiveCommand.CreateFromTask<TransitionLevelMeta>(HandleDeleteTransitionLevel);
+
+        _changeTracker.HasUnsavedChangesObservable.ObserveOn(RxApp.MainThreadScheduler).Subscribe(hasUnsavedChanges =>
+        {
+            HasUnsavedChanges = hasUnsavedChanges;
+        }).DisposeWith(_disposables);
 
         _disposables.Add(AtisStationChanged);
         _disposables.Add(TemplateVariableClicked);
@@ -222,7 +227,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _routineObservationTime, value);
-            TrackChanges(nameof(RoutineObservationTime), value);
+            _changeTracker.TrackChange(nameof(RoutineObservationTime), value);
         }
     }
 
@@ -235,7 +240,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _observationTimeTextTemplate, value);
-            TrackChanges(nameof(ObservationTimeTextTemplate), value);
+            _changeTracker.TrackChange(nameof(ObservationTimeTextTemplate), value);
         }
     }
 
@@ -248,7 +253,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _observationTimeVoiceTemplate, value);
-            TrackChanges(nameof(ObservationTimeVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(ObservationTimeVoiceTemplate), value);
         }
     }
 
@@ -261,7 +266,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _speakWindSpeedLeadingZero, value);
-            TrackChanges(nameof(SpeakWindSpeedLeadingZero), value);
+            _changeTracker.TrackChange(nameof(SpeakWindSpeedLeadingZero), value);
         }
     }
 
@@ -274,7 +279,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _magneticVariationEnabled, value);
-            TrackChanges(nameof(MagneticVariationEnabled), value);
+            _changeTracker.TrackChange(nameof(MagneticVariationEnabled), value);
         }
     }
 
@@ -287,7 +292,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _magneticVariationValue, value);
-            TrackChanges(nameof(MagneticVariationValue), value);
+            _changeTracker.TrackChange(nameof(MagneticVariationValue), value);
         }
     }
 
@@ -300,7 +305,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardWindTextTemplate, value);
-            TrackChanges(nameof(StandardWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(StandardWindTextTemplate), value);
         }
     }
 
@@ -313,7 +318,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardWindVoiceTemplate, value);
-            TrackChanges(nameof(StandardWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(StandardWindVoiceTemplate), value);
         }
     }
 
@@ -326,7 +331,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardGustWindTextTemplate, value);
-            TrackChanges(nameof(StandardGustWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(StandardGustWindTextTemplate), value);
         }
     }
 
@@ -339,7 +344,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _standardGustWindVoiceTemplate, value);
-            TrackChanges(nameof(StandardGustWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(StandardGustWindVoiceTemplate), value);
         }
     }
 
@@ -352,7 +357,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableWindTextTemplate, value);
-            TrackChanges(nameof(VariableWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableWindTextTemplate), value);
         }
     }
 
@@ -365,7 +370,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableWindVoiceTemplate, value);
-            TrackChanges(nameof(VariableWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableWindVoiceTemplate), value);
         }
     }
 
@@ -378,7 +383,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableGustWindTextTemplate, value);
-            TrackChanges(nameof(VariableGustWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableGustWindTextTemplate), value);
         }
     }
 
@@ -391,7 +396,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableGustWindVoiceTemplate, value);
-            TrackChanges(nameof(VariableGustWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableGustWindVoiceTemplate), value);
         }
     }
 
@@ -404,7 +409,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableDirectionWindTextTemplate, value);
-            TrackChanges(nameof(VariableDirectionWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableDirectionWindTextTemplate), value);
         }
     }
 
@@ -417,7 +422,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _variableDirectionWindVoiceTemplate, value);
-            TrackChanges(nameof(VariableDirectionWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(VariableDirectionWindVoiceTemplate), value);
         }
     }
 
@@ -430,7 +435,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindTextTemplate, value);
-            TrackChanges(nameof(CalmWindTextTemplate), value);
+            _changeTracker.TrackChange(nameof(CalmWindTextTemplate), value);
         }
     }
 
@@ -443,7 +448,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindVoiceTemplate, value);
-            TrackChanges(nameof(CalmWindVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(CalmWindVoiceTemplate), value);
         }
     }
 
@@ -456,7 +461,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _calmWindSpeed, value);
-            TrackChanges(nameof(CalmWindSpeed), value);
+            _changeTracker.TrackChange(nameof(CalmWindSpeed), value);
         }
     }
 
@@ -469,7 +474,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityTextTemplate, value);
-            TrackChanges(nameof(VisibilityTextTemplate), value);
+            _changeTracker.TrackChange(nameof(VisibilityTextTemplate), value);
         }
     }
 
@@ -482,7 +487,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityVoiceTemplate, value);
-            TrackChanges(nameof(VisibilityVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(VisibilityVoiceTemplate), value);
         }
     }
 
@@ -495,7 +500,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _presentWeatherTextTemplate, value);
-            TrackChanges(nameof(PresentWeatherTextTemplate), value);
+            _changeTracker.TrackChange(nameof(PresentWeatherTextTemplate), value);
         }
     }
 
@@ -508,7 +513,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _presentWeatherVoiceTemplate, value);
-            TrackChanges(nameof(PresentWeatherVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(PresentWeatherVoiceTemplate), value);
         }
     }
 
@@ -521,7 +526,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _recentWeatherTextTemplate, value);
-            TrackChanges(nameof(RecentWeatherTextTemplate), value);
+            _changeTracker.TrackChange(nameof(RecentWeatherTextTemplate), value);
         }
     }
 
@@ -534,7 +539,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _recentWeatherVoiceTemplate, value);
-            TrackChanges(nameof(RecentWeatherVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(RecentWeatherVoiceTemplate), value);
         }
     }
 
@@ -547,7 +552,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsTextTemplate, value);
-            TrackChanges(nameof(CloudsTextTemplate), value);
+            _changeTracker.TrackChange(nameof(CloudsTextTemplate), value);
         }
     }
 
@@ -560,7 +565,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsVoiceTemplate, value);
-            TrackChanges(nameof(CloudsVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(CloudsVoiceTemplate), value);
         }
     }
 
@@ -573,7 +578,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureTextTemplate, value);
-            TrackChanges(nameof(TemperatureTextTemplate), value);
+            _changeTracker.TrackChange(nameof(TemperatureTextTemplate), value);
         }
     }
 
@@ -586,7 +591,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureVoiceTemplate, value);
-            TrackChanges(nameof(TemperatureVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(TemperatureVoiceTemplate), value);
         }
     }
 
@@ -599,7 +604,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointTextTemplate, value);
-            TrackChanges(nameof(DewpointTextTemplate), value);
+            _changeTracker.TrackChange(nameof(DewpointTextTemplate), value);
         }
     }
 
@@ -612,7 +617,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointVoiceTemplate, value);
-            TrackChanges(nameof(DewpointVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(DewpointVoiceTemplate), value);
         }
     }
 
@@ -625,7 +630,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterTextTemplate, value);
-            TrackChanges(nameof(AltimeterTextTemplate), value);
+            _changeTracker.TrackChange(nameof(AltimeterTextTemplate), value);
         }
     }
 
@@ -638,7 +643,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterVoiceTemplate, value);
-            TrackChanges(nameof(AltimeterVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(AltimeterVoiceTemplate), value);
         }
     }
 
@@ -651,7 +656,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementTextTemplate, value);
-            TrackChanges(nameof(ClosingStatementTextTemplate), value);
+            _changeTracker.TrackChange(nameof(ClosingStatementTextTemplate), value);
         }
     }
 
@@ -664,7 +669,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementVoiceTemplate, value);
-            TrackChanges(nameof(ClosingStatementVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(ClosingStatementVoiceTemplate), value);
         }
     }
 
@@ -677,7 +682,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _notamsTextTemplate, value);
-            TrackChanges(nameof(NotamsTextTemplate), value);
+            _changeTracker.TrackChange(nameof(NotamsTextTemplate), value);
         }
     }
 
@@ -690,7 +695,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _notamsVoiceTemplate, value);
-            TrackChanges(nameof(NotamsVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(NotamsVoiceTemplate), value);
         }
     }
 
@@ -703,7 +708,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorth, value);
-            TrackChanges(nameof(VisibilityNorth), value);
+            _changeTracker.TrackChange(nameof(VisibilityNorth), value);
         }
     }
 
@@ -716,7 +721,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorthEast, value);
-            TrackChanges(nameof(VisibilityNorthEast), value);
+            _changeTracker.TrackChange(nameof(VisibilityNorthEast), value);
         }
     }
 
@@ -729,7 +734,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityEast, value);
-            TrackChanges(nameof(VisibilityEast), value);
+            _changeTracker.TrackChange(nameof(VisibilityEast), value);
         }
     }
 
@@ -742,7 +747,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouthEast, value);
-            TrackChanges(nameof(VisibilitySouthEast), value);
+            _changeTracker.TrackChange(nameof(VisibilitySouthEast), value);
         }
     }
 
@@ -755,7 +760,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouth, value);
-            TrackChanges(nameof(VisibilitySouth), value);
+            _changeTracker.TrackChange(nameof(VisibilitySouth), value);
         }
     }
 
@@ -768,7 +773,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilitySouthWest, value);
-            TrackChanges(nameof(VisibilitySouthWest), value);
+            _changeTracker.TrackChange(nameof(VisibilitySouthWest), value);
         }
     }
 
@@ -781,7 +786,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityWest, value);
-            TrackChanges(nameof(VisibilityWest), value);
+            _changeTracker.TrackChange(nameof(VisibilityWest), value);
         }
     }
 
@@ -794,7 +799,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityNorthWest, value);
-            TrackChanges(nameof(VisibilityNorthWest), value);
+            _changeTracker.TrackChange(nameof(VisibilityNorthWest), value);
         }
     }
 
@@ -807,7 +812,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityUnlimitedVisibilityVoice, value);
-            TrackChanges(nameof(VisibilityUnlimitedVisibilityVoice), value);
+            _changeTracker.TrackChange(nameof(VisibilityUnlimitedVisibilityVoice), value);
         }
     }
 
@@ -820,7 +825,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityUnlimitedVisibilityText, value);
-            TrackChanges(nameof(VisibilityUnlimitedVisibilityText), value);
+            _changeTracker.TrackChange(nameof(VisibilityUnlimitedVisibilityText), value);
         }
     }
 
@@ -833,7 +838,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityIncludeVisibilitySuffix, value);
-            TrackChanges(nameof(VisibilityIncludeVisibilitySuffix), value);
+            _changeTracker.TrackChange(nameof(VisibilityIncludeVisibilitySuffix), value);
         }
     }
 
@@ -846,7 +851,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _visibilityMetersCutoff, value);
-            TrackChanges(nameof(VisibilityMetersCutoff), value);
+            _changeTracker.TrackChange(nameof(VisibilityMetersCutoff), value);
         }
     }
 
@@ -859,7 +864,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsIdentifyCeilingLayer, value);
-            TrackChanges(nameof(CloudsIdentifyCeilingLayer), value);
+            _changeTracker.TrackChange(nameof(CloudsIdentifyCeilingLayer), value);
         }
     }
 
@@ -872,7 +877,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudsConvertToMetric, value);
-            TrackChanges(nameof(CloudsConvertToMetric), value);
+            _changeTracker.TrackChange(nameof(CloudsConvertToMetric), value);
         }
     }
 
@@ -885,7 +890,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _undeterminedLayerAltitudeText, value);
-            TrackChanges(nameof(UndeterminedLayerAltitudeText), value);
+            _changeTracker.TrackChange(nameof(UndeterminedLayerAltitudeText), value);
         }
     }
 
@@ -898,7 +903,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _undeterminedLayerAltitudeVoice, value);
-            TrackChanges(nameof(UndeterminedLayerAltitudeVoice), value);
+            _changeTracker.TrackChange(nameof(UndeterminedLayerAltitudeVoice), value);
         }
     }
 
@@ -911,7 +916,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _automaticCbDetectionText, value);
-            TrackChanges(nameof(AutomaticCbDetectionText), value);
+            _changeTracker.TrackChange(nameof(AutomaticCbDetectionText), value);
         }
     }
 
@@ -924,7 +929,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _automaticCbDetectionVoice, value);
-            TrackChanges(nameof(AutomaticCbDetectionVoice), value);
+            _changeTracker.TrackChange(nameof(AutomaticCbDetectionVoice), value);
         }
     }
 
@@ -937,7 +942,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _cloudHeightAltitudeInHundreds, value);
-            TrackChanges(nameof(CloudHeightAltitudeInHundreds), value);
+            _changeTracker.TrackChange(nameof(CloudHeightAltitudeInHundreds), value);
         }
     }
 
@@ -950,7 +955,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureUsePlusPrefix, value);
-            TrackChanges(nameof(TemperatureUsePlusPrefix), value);
+            _changeTracker.TrackChange(nameof(TemperatureUsePlusPrefix), value);
         }
     }
 
@@ -963,7 +968,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _temperatureSpeakLeadingZero, value);
-            TrackChanges(nameof(TemperatureSpeakLeadingZero), value);
+            _changeTracker.TrackChange(nameof(TemperatureSpeakLeadingZero), value);
         }
     }
 
@@ -976,7 +981,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointUsePlusPrefix, value);
-            TrackChanges(nameof(DewpointUsePlusPrefix), value);
+            _changeTracker.TrackChange(nameof(DewpointUsePlusPrefix), value);
         }
     }
 
@@ -989,7 +994,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _dewpointSpeakLeadingZero, value);
-            TrackChanges(nameof(DewpointSpeakLeadingZero), value);
+            _changeTracker.TrackChange(nameof(DewpointSpeakLeadingZero), value);
         }
     }
 
@@ -1002,7 +1007,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _altimeterSpeakDecimal, value);
-            TrackChanges(nameof(AltimeterSpeakDecimal), value);
+            _changeTracker.TrackChange(nameof(AltimeterSpeakDecimal), value);
         }
     }
 
@@ -1015,7 +1020,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _closingStatementAutoIncludeClosingStatement, value);
-            TrackChanges(nameof(ClosingStatementAutoIncludeClosingStatement), value);
+            _changeTracker.TrackChange(nameof(ClosingStatementAutoIncludeClosingStatement), value);
         }
     }
 
@@ -1037,7 +1042,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _transitionLevelTextTemplate, value);
-            TrackChanges(nameof(TransitionLevelTextTemplate), value);
+            _changeTracker.TrackChange(nameof(TransitionLevelTextTemplate), value);
         }
     }
 
@@ -1050,7 +1055,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         set
         {
             this.RaiseAndSetIfChanged(ref _transitionLevelVoiceTemplate, value);
-            TrackChanges(nameof(TransitionLevelVoiceTemplate), value);
+            _changeTracker.TrackChange(nameof(TransitionLevelVoiceTemplate), value);
         }
     }
 
@@ -1576,26 +1581,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
-        // Check if there are unsaved changes before saving
-        var anyChanges = _fieldHistory.Any(entry => !AreValuesEqual(entry.Value.OriginalValue, entry.Value.CurrentValue));
-
-        // If there are unsaved changes, mark as applied and reset HasUnsavedChanges
-        if (anyChanges)
-        {
-            // Apply changes and reset HasUnsavedChanges
-            foreach (var key in _fieldHistory.Keys.ToList())
-            {
-                var (_, currentValue) = _fieldHistory[key];
-
-                // After applying changes, set the original value to the current value (the saved value)
-                _fieldHistory[key] = (currentValue, currentValue);
-            }
-
-            HasUnsavedChanges = false;
-            return true;
-        }
-
-        return false;
+        return _changeTracker.ApplyChangesIfNeeded();
     }
 
     private void HandleAtisStationChanged(AtisStation? station)
@@ -1713,7 +1699,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         }
 
         // Track initial PresentWeatherTypes.
-        TrackChanges(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
+        _changeTracker.TrackChange(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
             new PresentWeatherMeta(item.Key, item.Text, item.Spoken)).ToList());
 
         CloudTypes = [];
@@ -1723,7 +1709,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         }
 
         // Track initial CloudTypes.
-        TrackChanges(nameof(CloudTypes), CloudTypes?.Select(item =>
+        _changeTracker.TrackChange(nameof(CloudTypes), CloudTypes?.Select(item =>
             new CloudTypeMeta(item.Acronym, item.Spoken, item.Text)).ToList());
 
         ConvectiveCloudTypes = [];
@@ -1733,7 +1719,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         }
 
         // Track initial ConvectiveCloudTypes.
-        TrackChanges(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
+        _changeTracker.TrackChange(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
             new ConvectiveCloudTypeMeta(item.Key, item.Value)).ToList());
 
         TransitionLevelTextTemplate = station.AtisFormat.TransitionLevel.Template.Text;
@@ -1746,7 +1732,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         }
 
         // Track initial TransitionLevels.
-        TrackChanges(nameof(TransitionLevels), TransitionLevels?.Select(item =>
+        _changeTracker.TrackChange(nameof(TransitionLevels), TransitionLevels?.Select(item =>
             new TransitionLevelMeta(item.Low, item.High, item.Altitude)).ToList());
 
         if (PresentWeatherTypes != null)
@@ -1878,19 +1864,19 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             switch (e.DataGridName)
             {
                 case nameof(PresentWeatherTypes):
-                    TrackChanges(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
+                    _changeTracker.TrackChange(nameof(PresentWeatherTypes), PresentWeatherTypes?.Select(item =>
                         new PresentWeatherMeta(item.Key, item.Text, item.Spoken)).ToList());
                     break;
                 case nameof(CloudTypes):
-                    TrackChanges(nameof(CloudTypes), CloudTypes?.Select(item =>
+                    _changeTracker.TrackChange(nameof(CloudTypes), CloudTypes?.Select(item =>
                         new CloudTypeMeta(item.Acronym, item.Spoken, item.Text)).ToList());
                     break;
                 case nameof(ConvectiveCloudTypes):
-                    TrackChanges(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
+                    _changeTracker.TrackChange(nameof(ConvectiveCloudTypes), ConvectiveCloudTypes?.Select(item =>
                         new ConvectiveCloudTypeMeta(item.Key, item.Value)).ToList());
                     break;
                 case nameof(TransitionLevels):
-                    TrackChanges(nameof(TransitionLevels), TransitionLevels?.Select(item =>
+                    _changeTracker.TrackChange(nameof(TransitionLevels), TransitionLevels?.Select(item =>
                         new TransitionLevelMeta(item.Low, item.High, item.Altitude)).ToList());
                     break;
             }
@@ -1948,76 +1934,5 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         return (PresentWeatherFilterAcronym && weather.Key.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase)) ||
                (PresentWeatherFilterText && weather.Text.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase)) ||
                (PresentWeatherFilterSpoken && weather.Spoken.Contains(_presentWeatherSearchTerm, StringComparison.InvariantCultureIgnoreCase));
-    }
-
-    private void TrackChanges(string propertyName, object? currentValue)
-    {
-        if (_fieldHistory.TryGetValue(propertyName, out var value))
-        {
-            var (originalValue, _) = value;
-
-            // If the property has been set before, update the current value
-            _fieldHistory[propertyName] = (originalValue, currentValue);
-
-            // Check for unsaved changes after the update
-            CheckForUnsavedChanges();
-        }
-        else
-        {
-            // If this is the first time setting the value, initialize the original value
-            _fieldHistory[propertyName] = (currentValue, currentValue);
-
-            // Check for unsaved changes after the update
-            CheckForUnsavedChanges();
-        }
-    }
-
-    private bool AreValuesEqual(object? originalValue, object? currentValue)
-    {
-        // If both are null, consider them equal
-        if (originalValue == null && currentValue == null)
-            return true;
-
-        // If one is null and the other is not, they are not equal
-        if (originalValue == null || currentValue == null)
-            return false;
-
-        // Handle comparison for nullable types like int?, string?, bool? etc.
-        if (originalValue is string originalStr && currentValue is string currentStr)
-        {
-            return originalStr == currentStr;
-        }
-
-        // Compare nullable int (int?)
-        if (originalValue is int originalInt && currentValue is int currentInt)
-        {
-            return originalInt == currentInt;
-        }
-
-        // Compare nullable bool (bool?)
-        if (originalValue is bool originalBool && currentValue is bool currentBool)
-        {
-            return originalBool == currentBool;
-        }
-
-        if (originalValue is IEnumerable<object> originalEnumerable &&
-            currentValue is IEnumerable<object> currentEnumerable)
-        {
-            return AreListsEqual(originalEnumerable, currentEnumerable);
-        }
-
-        // For non-nullable types (or if types are not specifically handled above), use Equals
-        return originalValue.Equals(currentValue);
-    }
-
-    private bool AreListsEqual(IEnumerable<object> list1, IEnumerable<object> list2)
-    {
-        return list1.SequenceEqual(list2);
-    }
-
-    private void CheckForUnsavedChanges()
-    {
-        var anyChanges = _fieldHistory.Any(entry => !AreValuesEqual(entry.Value.OriginalValue, entry.Value.CurrentValue));
-        HasUnsavedChanges = anyChanges;
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -1592,9 +1592,10 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             }
 
             HasUnsavedChanges = false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     private void HandleAtisStationChanged(AtisStation? station)

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -285,13 +285,13 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Applies the general configuration settings for the current session and validates the input data.
     /// </summary>
-    /// <returns>
-    /// A boolean value indicating whether the configuration was successfully applied.
-    /// </returns>
-    public bool ApplyConfig()
+    /// <param name="hasErrors">A value indicating whether there are errors.</param>
+    /// <returns>A boolean value indicating whether the configuration was successfully applied.</returns>
+    public bool ApplyConfig(out bool hasErrors)
     {
         if (SelectedStation == null)
         {
+            hasErrors = false;
             return false;
         }
 
@@ -384,6 +384,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
 
         if (HasErrors || ShowDuplicateAtisTypeError)
         {
+            hasErrors = true;
             return false;
         }
 
@@ -392,6 +393,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
+        hasErrors = false;
         return _changeTracker.ApplyChangesIfNeeded();
     }
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -404,9 +404,10 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
             }
 
             HasUnsavedChanges = false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     private void HandleUpdateProperties(AtisStation? station)

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -417,6 +417,9 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
             return;
         }
 
+        ClearAllErrors();
+        ShowDuplicateAtisTypeError = false;
+
         _fieldHistory.Clear();
 
         SelectedTabIndex = -1;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -417,6 +417,8 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
             return;
         }
 
+        _fieldHistory.Clear();
+
         SelectedTabIndex = -1;
         SelectedStation = station;
         Frequency = station.Frequency > 0

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/GeneralConfigViewModel.cs
@@ -312,7 +312,7 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
     {
         if (SelectedStation == null)
         {
-            return true;
+            return false;
         }
 
         ClearAllErrors();
@@ -412,6 +412,11 @@ public class GeneralConfigViewModel : ReactiveViewModelBase, IDisposable
         if (_sessionManager.CurrentProfile != null)
         {
             _profileRepository.Save(_sessionManager.CurrentProfile);
+        }
+
+        if (!HasUnsavedChanges)
+        {
+            return false;
         }
 
         HasUnsavedChanges = false;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -392,13 +392,13 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Applies the configuration changes for the currently selected preset and updates the session profile if applicable.
     /// </summary>
-    /// <returns>
-    /// A boolean value indicating whether the configuration was successfully applied. Returns true if successful; otherwise, false.
-    /// </returns>
-    public bool ApplyConfig()
+    /// <param name="hasErrors">A value indicating whether there are errors.</param>
+    /// <returns>A boolean value indicating whether the configuration was successfully applied.</returns>
+    public bool ApplyConfig(out bool hasErrors)
     {
         if (SelectedPreset == null)
         {
+            hasErrors = false;
             return false;
         }
 
@@ -450,6 +450,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
 
         if (HasErrors)
         {
+            hasErrors = true;
             return false;
         }
 
@@ -458,6 +459,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
+        hasErrors = false;
         return _changeTracker.ApplyChangesIfNeeded();
     }
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -799,14 +799,6 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
         }
 
         SelectedPreset = preset;
-
-        UseExternalAtisGenerator = false;
-        ExternalGeneratorTextUrl = null;
-        ExternalGeneratorVoiceUrl = null;
-        ExternalGeneratorArrivalRunways = null;
-        ExternalGeneratorDepartureRunways = null;
-        ExternalGeneratorApproaches = null;
-        ExternalGeneratorRemarks = null;
         ExternalGeneratorSandboxResponseText = null;
         AtisTemplateText = SelectedPreset?.Template ?? string.Empty;
 
@@ -907,6 +899,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             AtisTemplateText = string.Empty;
             Presets = new ObservableCollection<AtisPreset>(SelectedStation.Presets);
             EventBus.Instance.Publish(new StationPresetsChanged(SelectedStation.Id));
+            _fieldHistory.Clear();
             HasUnsavedChanges = false;
         }
     }
@@ -936,6 +929,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
 
         PopulateContractions();
 
+        _fieldHistory.Clear();
         HasUnsavedChanges = false;
     }
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -419,7 +419,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
     {
         if (SelectedPreset == null)
         {
-            return true;
+            return false;
         }
 
         IsSandboxPlaybackActive = false;
@@ -478,8 +478,12 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
-        HasUnsavedChanges = false;
+        if (!HasUnsavedChanges)
+        {
+            return false;
+        }
 
+        HasUnsavedChanges = false;
         return true;
     }
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -516,6 +516,7 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             AtisBuilderVoiceResponse = null;
 
             await _externalGeneratorCancellationTokenSource.CancelAsync();
+            _externalGeneratorCancellationTokenSource.Dispose();
             _externalGeneratorCancellationTokenSource = new CancellationTokenSource();
             var localToken = _externalGeneratorCancellationTokenSource;
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
@@ -709,15 +709,15 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         }
         else
         {
-            if (!string.IsNullOrEmpty(_previousFreeTextNotams))
+            var freeText = !string.IsNullOrEmpty(_previousFreeTextNotams)
+                ? _previousFreeTextNotams.Trim()
+                : SelectedPreset.Notams?.Trim();
+
+            if (!string.IsNullOrEmpty(freeText))
             {
-                NotamsTextDocument.Insert(0, _previousFreeTextNotams.Trim() + " ");
-                _notamFreeTextOffset = _previousFreeTextNotams.Trim().Length + 1;
-            }
-            else if (!string.IsNullOrEmpty(SelectedPreset.Notams))
-            {
-                NotamsTextDocument.Insert(0, SelectedPreset.Notams.Trim() + " ");
-                _notamFreeTextOffset = SelectedPreset.Notams.Trim().Length + 1;
+                var addSpace = staticDefinitions.Count > 0;
+                NotamsTextDocument.Insert(0, freeText + (addSpace ? " " : ""));
+                _notamFreeTextOffset = freeText.Length + (addSpace ? 1 : 0);
             }
 
             // Insert static definitions after free-text
@@ -801,15 +801,15 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         }
         else
         {
-            if (!string.IsNullOrEmpty(_previousFreeTextAirportConditions))
+            var freeText = !string.IsNullOrEmpty(_previousFreeTextAirportConditions)
+                ? _previousFreeTextAirportConditions.Trim()
+                : SelectedPreset.AirportConditions?.Trim();
+
+            if (!string.IsNullOrEmpty(freeText))
             {
-                AirportConditionsTextDocument.Insert(0, _previousFreeTextAirportConditions.Trim() + " ");
-                _airportConditionsFreeTextOffset = _previousFreeTextAirportConditions.Trim().Length + 1;
-            }
-            else if (!string.IsNullOrEmpty(SelectedPreset.AirportConditions))
-            {
-                AirportConditionsTextDocument.Insert(0, SelectedPreset.AirportConditions.Trim() + " ");
-                _airportConditionsFreeTextOffset = SelectedPreset.AirportConditions.Trim().Length + 1;
+                var addSpace = staticDefinitions.Count > 0;
+                AirportConditionsTextDocument.Insert(0, freeText + (addSpace ? " " : ""));
+                _airportConditionsFreeTextOffset = freeText.Length + (addSpace ? 1 : 0);
             }
 
             // Insert static definitions after free-text

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -402,7 +402,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
 
             EventBus.Instance.Publish(new AtisStationDeleted(SelectedAtisStation.Id));
             _sessionManager.CurrentProfile.Stations.Remove(SelectedAtisStation);
-            _appConfig.SaveConfig();
+            _profileRepository.Save(_sessionManager.CurrentProfile);
             _atisStationSource.Remove(SelectedAtisStation);
             SelectedAtisStation = null;
             ResetFields();

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -455,18 +455,16 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             context.RaiseError("StationName", "Name is required.");
                         }
 
-                        decimal parsedFrequency = 0;
+                        uint parsedFrequency = 0;
                         if (string.IsNullOrEmpty(context.Frequency))
                         {
                             context.RaiseError("Frequency", "Frequency is required.");
                         }
-                        else if (decimal.TryParse(context.Frequency, CultureInfo.InvariantCulture, out parsedFrequency))
+                        else if (!FrequencyValidator.TryParseMHz(context.Frequency, out parsedFrequency, out var error))
                         {
-                            parsedFrequency = parsedFrequency * 1000 * 1000;
-                            if (parsedFrequency is < 118000000 or > 137000000)
+                            if (error != null)
                             {
-                                context.RaiseError("Frequency",
-                                    "Invalid frequency format. The accepted frequency range is 118.000-137.000 MHz.");
+                                context.RaiseError("Frequency", error);
                             }
                         }
 
@@ -491,7 +489,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             clone.Identifier = context.AirportIdentifier;
                             clone.Name = context.StationName;
                             clone.AtisType = context.AtisType;
-                            clone.Frequency = (uint)parsedFrequency;
+                            clone.Frequency = parsedFrequency;
 
                             _sessionManager.CurrentProfile.Stations.Add(clone);
                             _profileRepository.Save(_sessionManager.CurrentProfile);
@@ -771,18 +769,16 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             context.RaiseError("StationName", "Name is required.");
                         }
 
-                        decimal parsedFrequency = 0;
+                        uint parsedFrequency = 0;
                         if (string.IsNullOrEmpty(context.Frequency))
                         {
                             context.RaiseError("Frequency", "Frequency is required.");
                         }
-                        else if (decimal.TryParse(context.Frequency, CultureInfo.InvariantCulture, out parsedFrequency))
+                        else if (!FrequencyValidator.TryParseMHz(context.Frequency, out parsedFrequency, out var error))
                         {
-                            parsedFrequency = parsedFrequency * 1000 * 1000;
-                            if (parsedFrequency is < 118000000 or > 137000000)
+                            if (error != null)
                             {
-                                context.RaiseError("Frequency",
-                                    "Invalid frequency format. The accepted frequency range is 118.000-137.000 MHz.");
+                                context.RaiseError("Frequency", error);
                             }
                         }
 
@@ -825,7 +821,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                         {
                             Identifier = context.AirportIdentifier,
                             Name = context.StationName,
-                            Frequency = (uint)parsedFrequency,
+                            Frequency = parsedFrequency,
                             AtisType = context.AtisType
                         };
                         _sessionManager.CurrentProfile.Stations?.Add(station);

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -598,6 +598,9 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
             if (_dialogOwner == null)
                 return;
 
+            if (_sessionManager.CurrentProfile == null)
+                return;
+
             var filters = new List<FilePickerFileType> { new("ATIS Station (*.station)") { Patterns = ["*.station"] } };
             var files = await FilePickerExtensions.OpenFilePickerAsync(filters, "Import ATIS Station");
 
@@ -621,7 +624,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                                 "Confirm",
                                 MessageBoxButton.YesNo, MessageBoxIcon.Information) == MessageBoxResult.Yes)
                         {
-                            _sessionManager.CurrentProfile?.Stations?.RemoveAll(x =>
+                            _sessionManager.CurrentProfile.Stations.RemoveAll(x =>
                                 x.Identifier == station.Identifier && x.AtisType == station.AtisType);
                         }
                         else
@@ -630,8 +633,8 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                         }
                     }
 
-                    _sessionManager.CurrentProfile?.Stations?.Add(station);
-                    _appConfig.SaveConfig();
+                    _sessionManager.CurrentProfile.Stations.Add(station);
+                    _profileRepository.Save(_sessionManager.CurrentProfile);
                     _atisStationSource.Add(station);
                     EventBus.Instance.Publish(new AtisStationAdded(station.Id));
                 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -854,9 +854,8 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
             (formatting.HasValue && formatting.Value))
         {
             EventBus.Instance.Publish(new AtisStationUpdated(SelectedAtisStation.Id));
+            window?.Close();
         }
-
-        window?.Close();
     }
 
     private void HandleApplyChanges()

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive;
@@ -846,23 +845,30 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
             return;
         }
 
-        var general = GeneralConfigViewModel?.ApplyConfig();
-        var presets = PresetsViewModel?.ApplyConfig();
-        var formatting = FormattingViewModel?.ApplyChanges();
+        var hasGeneralErrors = false;
+        var hasPresetsErrors = false;
+        var hasFormattingErrors = false;
+        var general = GeneralConfigViewModel?.ApplyConfig(out hasGeneralErrors);
+        var presets = PresetsViewModel?.ApplyConfig(out hasPresetsErrors);
+        var formatting = FormattingViewModel?.ApplyChanges(out hasFormattingErrors);
 
         if ((general.HasValue && general.Value) || (presets.HasValue && presets.Value) ||
             (formatting.HasValue && formatting.Value))
         {
             EventBus.Instance.Publish(new AtisStationUpdated(SelectedAtisStation.Id));
+        }
+
+        if (!hasGeneralErrors && !hasPresetsErrors && !hasFormattingErrors)
+        {
             window?.Close();
         }
     }
 
     private void HandleApplyChanges()
     {
-        GeneralConfigViewModel?.ApplyConfig();
-        PresetsViewModel?.ApplyConfig();
-        FormattingViewModel?.ApplyChanges();
+        GeneralConfigViewModel?.ApplyConfig(out _);
+        PresetsViewModel?.ApplyConfig(out _);
+        FormattingViewModel?.ApplyChanges(out _);
         SandboxViewModel?.ApplyConfig();
         RequiresDisconnect = true;
     }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -568,6 +568,9 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             // Save changes
                             _sessionManager.CurrentProfile.Stations = updatedStations;
                             _profileRepository.Save(_sessionManager.CurrentProfile);
+
+                            ResetFields();
+                            SelectedAtisStation = null;
                         }
                         catch (Exception ex)
                         {
@@ -679,9 +682,14 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                         }
                         else
                         {
-                            SelectedAtisStation.Name = context.UserValue.Trim();
-                            _profileRepository.Save(_sessionManager.CurrentProfile);
-                            _atisStationSource.Replace(SelectedAtisStation, SelectedAtisStation);
+                            var existing = _atisStationSource.Items.FirstOrDefault(x => x == SelectedAtisStation);
+                            if (existing != null)
+                            {
+                                existing.Name = context.UserValue.Trim();
+                                _profileRepository.Save(_sessionManager.CurrentProfile);
+                                ResetFields();
+                                SelectedAtisStation = null;
+                            }
                         }
                     }
                 };
@@ -853,22 +861,6 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         }
 
         window?.Close();
-
-        // var general = GeneralConfigViewModel?.ApplyConfig();
-        // var presets = PresetsViewModel?.ApplyConfig();
-        // var formatting = FormattingViewModel?.ApplyChanges();
-        // var sandbox = SandboxViewModel?.ApplyConfig();
-        //
-        // if (general != null && presets != null && formatting != null && sandbox != null && general.Value &&
-        //     presets.Value && formatting.Value && sandbox.Value)
-        // {
-        //     if (SelectedAtisStation != null && (HasUnsavedChanges || RequiresDisconnect))
-        //     {
-        //         EventBus.Instance.Publish(new AtisStationUpdated(SelectedAtisStation.Id));
-        //     }
-        //
-        //     window?.Close();
-        // }
     }
 
     private void HandleApplyChanges()

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive;
@@ -748,6 +749,21 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             context.RaiseError("StationName", "Name is required.");
                         }
 
+                        decimal parsedFrequency = 0;
+                        if (string.IsNullOrEmpty(context.Frequency))
+                        {
+                            context.RaiseError("Frequency", "Frequency is required.");
+                        }
+                        else if (decimal.TryParse(context.Frequency, CultureInfo.InvariantCulture, out parsedFrequency))
+                        {
+                            parsedFrequency = parsedFrequency * 1000 * 1000;
+                            if (parsedFrequency is < 118000000 or > 137000000)
+                            {
+                                context.RaiseError("Frequency",
+                                    "Invalid frequency format. The accepted frequency range is 118.000-137.000 MHz.");
+                            }
+                        }
+
                         if (context.HasErrors) return;
 
                         if (_atisStationSource.Items.Any(x =>
@@ -784,6 +800,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                             {
                                 Identifier = context.AirportIdentifier,
                                 Name = context.StationName,
+                                Frequency = (uint)parsedFrequency,
                                 AtisType = context.AtisType
                             };
                             _sessionManager.CurrentProfile.Stations.Add(station);

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -651,6 +651,9 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         if (SelectedAtisStation == null)
             return;
 
+        if (_sessionManager.CurrentProfile == null)
+            return;
+
         if (_dialogOwner == null)
             return;
 
@@ -681,15 +684,8 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                         else
                         {
                             SelectedAtisStation.Name = context.UserValue.Trim();
-                            _appConfig.SaveConfig();
-                            _atisStationSource.Edit(list =>
-                            {
-                                var item = list.FirstOrDefault(x => x.Id == SelectedAtisStation.Id);
-                                if (item != null)
-                                {
-                                    item.Name = context.UserValue.Trim();
-                                }
-                            });
+                            _profileRepository.Save(_sessionManager.CurrentProfile);
+                            _atisStationSource.Replace(SelectedAtisStation, SelectedAtisStation);
                         }
                     }
                 };

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -22,7 +22,6 @@ using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using Serilog;
-using Vatsim.Vatis.Config;
 using Vatsim.Vatis.Events;
 using Vatsim.Vatis.Events.EventBus;
 using Vatsim.Vatis.NavData;
@@ -43,7 +42,6 @@ namespace Vatsim.Vatis.Ui.ViewModels;
 /// </summary>
 public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposable
 {
-    private readonly IAppConfig _appConfig;
     private readonly ISessionManager _sessionManager;
     private readonly IWindowFactory _windowFactory;
     private readonly INavDataRepository _navDataRepository;
@@ -62,14 +60,13 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
     /// <summary>
     /// Initializes a new instance of the <see cref="AtisConfigurationWindowViewModel"/> class.
     /// </summary>
-    /// <param name="appConfig">The application configuration data.</param>
     /// <param name="sessionManager">The session manager instance.</param>
     /// <param name="windowFactory">The factory used to create application windows.</param>
     /// <param name="viewModelFactory">The factory used to create view models.</param>
     /// <param name="textToSpeechService">The text-to-speech service for the application.</param>
     /// <param name="navDataRepository">The navigation data repository.</param>
     /// <param name="profileRepository">The profile repository for managing user settings and profiles.</param>
-    public AtisConfigurationWindowViewModel(IAppConfig appConfig,
+    public AtisConfigurationWindowViewModel(
         ISessionManager sessionManager,
         IWindowFactory windowFactory,
         IViewModelFactory viewModelFactory,
@@ -77,7 +74,6 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         INavDataRepository navDataRepository,
         IProfileRepository profileRepository)
     {
-        _appConfig = appConfig;
         _sessionManager = sessionManager;
         _windowFactory = windowFactory;
         _viewModelFactory = viewModelFactory;

--- a/vATIS.Desktop/Ui/ViewModels/NewAtisStationDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/NewAtisStationDialogViewModel.cs
@@ -19,6 +19,7 @@ public class NewAtisStationDialogViewModel : ReactiveViewModelBase, IDisposable
     private DialogResult _dialogResult;
     private string? _airportIdentifier;
     private string? _stationName;
+    private string? _frequency;
     private AtisType _atisType = AtisType.Combined;
 
     /// <summary>
@@ -70,6 +71,15 @@ public class NewAtisStationDialogViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _stationName;
         set => this.RaiseAndSetIfChanged(ref _stationName, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the frequency of the ATIS station.
+    /// </summary>
+    public string? Frequency
+    {
+        get => _frequency;
+        set => this.RaiseAndSetIfChanged(ref _frequency, value);
     }
 
     /// <summary>

--- a/vATIS.Desktop/Utils/FrequencyValidator.cs
+++ b/vATIS.Desktop/Utils/FrequencyValidator.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+
+namespace Vatsim.Vatis.Utils;
+
+/// <summary>
+/// Provides utility methods for parsing and validating VHF radio frequency.
+/// </summary>
+public static class FrequencyValidator
+{
+    /// <summary>
+    /// Tries to parse a frequency string in MHz and validate it falls within the VHF aviation range.
+    /// </summary>
+    /// <param name="input">The input frequency string (e.g. "128.350" or "128350").</param>
+    /// <param name="hz">The parsed frequency in Hz (e.g., 128350000).</param>
+    /// <param name="error">An error message if the input is invalid.</param>
+    /// <returns>True if parsing and validation succeed; otherwise false.</returns>
+    public static bool TryParseMHz(string input, out uint hz, out string? error)
+    {
+        hz = 0;
+        error = null;
+
+        if (!decimal.TryParse(input, CultureInfo.InvariantCulture, out var mhz))
+        {
+            error = "Invalid frequency format.";
+            return false;
+        }
+
+        var parsedHz = (uint)(mhz * 1_000_000);
+
+        if (parsedHz is < 118_000_000 or > 137_000_000)
+        {
+            error = "Invalid frequency format. The accepted frequency range is 118.000–137.000 MHz.";
+            return false;
+        }
+
+        hz = parsedHz;
+        return true;
+    }
+}

--- a/vATIS.Desktop/Utils/FrequencyValidator.cs
+++ b/vATIS.Desktop/Utils/FrequencyValidator.cs
@@ -7,6 +7,11 @@ namespace Vatsim.Vatis.Utils;
 /// </summary>
 public static class FrequencyValidator
 {
+    private const string InvalidFormatError = "Invalid frequency format.";
+
+    private const string InvalidRangeError =
+        "Invalid frequency format. The accepted frequency range is 118.000–137.000 MHz.";
+
     /// <summary>
     /// Tries to parse a frequency string in MHz and validate it falls within the VHF aviation range.
     /// </summary>
@@ -21,7 +26,7 @@ public static class FrequencyValidator
 
         if (!decimal.TryParse(input, CultureInfo.InvariantCulture, out var mhz))
         {
-            error = "Invalid frequency format.";
+            error = InvalidFormatError;
             return false;
         }
 
@@ -29,7 +34,7 @@ public static class FrequencyValidator
 
         if (parsedHz is < 118_000_000 or > 137_000_000)
         {
-            error = "Invalid frequency format. The accepted frequency range is 118.000–137.000 MHz.";
+            error = InvalidRangeError;
             return false;
         }
 

--- a/vATIS.Desktop/Utils/FrequencyValidator.cs
+++ b/vATIS.Desktop/Utils/FrequencyValidator.cs
@@ -1,3 +1,8 @@
+// <copyright file="FrequencyValidator.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
 using System.Globalization;
 
 namespace Vatsim.Vatis.Utils;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added frequency input and validation when creating or copying ATIS stations.
  - Introduced a disconnect-required indicator when applying configuration changes.
  - Enabled two-way text binding for ATIS template editing.
  - Added naming to DataGrid edit behaviors for better event context.

- **Improvements**
  - Enhanced detection and tracking of unsaved changes across configuration, formatting, and preset editors with detailed per-property change history via a new centralized change tracker.
  - Improved handling of DataGrid cell editing events with clearer identification of the source grid.
  - Refined logic for detecting user edits in sandbox text fields, ignoring read-only segments.
  - Streamlined insertion and handling of free-text and static definitions in sandbox views.
  - Strengthened frequency validation logic with detailed error reporting.
  - Improved null safety when modifying stations without a selected profile.
  - Simplified event publishing and UI state management in configuration dialogs.
  - Removed redundant unsaved changes flags and replaced with reactive change tracking.

- **Bug Fixes**
  - Added null checks to prevent errors when modifying stations without a selected profile.

- **Style**
  - Removed unused XML namespaces from several views for cleaner XAML files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->