### PR TITLE
Only show mini-window controls if CTRL is pressed

### DIFF
--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -9,6 +9,11 @@
         mc:Ignorable="d"
         x:Name="Window"
         x:Class="Vatsim.Vatis.Ui.Windows.CompactWindow"
+        KeyDown="OnKeyDown"
+        KeyUp="OnKeyUp"
+        PointerEntered="OnPointerEntered"
+        PointerExited="OnPointerExited"
+        PointerPressed="OnPointerPressed"
         MinHeight="30"
         MinWidth="90"
         MaxWidth="400"
@@ -45,10 +50,7 @@
             BorderBrush="Black"
             BorderThickness="1"
             Background="#323232"
-            ClipToBounds="True"
-            PointerEntered="OnPointerEntered"
-            PointerExited="OnPointerExited"
-            PointerPressed="OnPointerPressed">
+            ClipToBounds="True">
         <Panel ClipToBounds="True">
             <StackPanel Name="WindowControls" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" Spacing="3" ZIndex="1" Margin="3" IsVisible="{Binding IsControlsVisible, DataType=vm:CompactWindowViewModel}">
                 <ToggleButton Theme="{StaticResource ActionToggle}" Command="{Binding ToggleMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" IsChecked="{Binding ShowMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Mode=OneWay, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" />

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml.cs
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml.cs
@@ -20,6 +20,8 @@ namespace Vatsim.Vatis.Ui.Windows;
 /// </summary>
 public partial class CompactWindow : ReactiveWindow<CompactWindowViewModel>, ICloseable, IDialogOwner
 {
+    private bool _isPointerInside;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CompactWindow"/> class with the specified view model.
     /// </summary>
@@ -120,20 +122,40 @@ public partial class CompactWindow : ReactiveWindow<CompactWindowViewModel>, ICl
         }
         else
         {
-            // Keep default alignment when fully visible
+            // Keep the default alignment when fully visible
             WindowControls.HorizontalAlignment = HorizontalAlignment.Right;
         }
     }
 
     private void OnPointerEntered(object? sender, PointerEventArgs e)
     {
-        if (ViewModel != null)
+        _isPointerInside = true;
+
+        if (ViewModel != null && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             ViewModel.IsControlsVisible = true;
         }
     }
 
     private void OnPointerExited(object? sender, PointerEventArgs e)
+    {
+        _isPointerInside = false;
+
+        if (ViewModel != null)
+        {
+            ViewModel.IsControlsVisible = false;
+        }
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (ViewModel != null && e.KeyModifiers.HasFlag(KeyModifiers.Control) && _isPointerInside)
+        {
+            ViewModel.IsControlsVisible = true;
+        }
+    }
+
+    private void OnKeyUp(object? sender, KeyEventArgs e)
     {
         if (ViewModel != null)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Controls in the compact window are now shown only when the pointer is inside the window and the Control key is pressed.
  - Controls automatically hide when the pointer leaves the window or the Control key is released.

- **Bug Fixes**
  - Improved consistency in showing and hiding controls based on pointer and keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->