### PR TITLE
[VATIS-187] Fix missing closing statement variable

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -654,21 +654,19 @@ public class AtisBuilder : IAtisBuilder
         var closingTextTemplate = station.AtisFormat.ClosingStatement.Template.Text;
         var closingVoiceTemplate = station.AtisFormat.ClosingStatement.Template.Voice;
 
-        if (!string.IsNullOrEmpty(closingTextTemplate) && !string.IsNullOrEmpty(closingVoiceTemplate))
+        if (!string.IsNullOrEmpty(closingTextTemplate))
         {
             closingTextTemplate = Regex.Replace(closingTextTemplate, @"{letter}", currentAtisLetter.ToString());
             closingTextTemplate = Regex.Replace(closingTextTemplate, @"{letter\|word}", currentAtisLetter.ToPhonetic());
-
-            closingVoiceTemplate = Regex.Replace(closingVoiceTemplate, @"{letter}", currentAtisLetter.ToString());
-            closingVoiceTemplate =
-                Regex.Replace(closingVoiceTemplate, @"{letter\|word}", currentAtisLetter.ToPhonetic());
-
-            variables.Add(new AtisVariable("CLOSING", closingTextTemplate, closingVoiceTemplate));
         }
-        else
+
+        if (!string.IsNullOrEmpty(closingVoiceTemplate))
         {
-            variables.Add(new AtisVariable("CLOSING", "", ""));
+            closingVoiceTemplate = Regex.Replace(closingVoiceTemplate, @"{letter}", currentAtisLetter.ToString());
+            closingVoiceTemplate = Regex.Replace(closingVoiceTemplate, @"{letter\|word}", currentAtisLetter.ToPhonetic());
         }
+
+        variables.Add(new AtisVariable("CLOSING", closingTextTemplate ?? "", closingVoiceTemplate ?? ""));
 
         return variables;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of closing statement templates to ensure the closing message is always included when available, even if only one template (text or voice) is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->