### PR TITLE
Observed ATIS station improvements

### DIFF
--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -208,7 +208,6 @@ public class NetworkConnection : INetworkConnection, IDisposable
         }
 
         ArgumentNullException.ThrowIfNull(_atisStation.Identifier);
-        await _metarRepository.GetMetar(_atisStation.Identifier, monitor: true);
     }
 
     /// <inheritdoc />
@@ -470,6 +469,12 @@ public class NetworkConnection : INetworkConnection, IDisposable
         // building the ATIS.
         NetworkConnected(this, EventArgs.Empty);
         _isCallsignInUse = false;
+
+        // Wait until we have established FSD connection to request METAR.
+        if (_atisStation != null)
+        {
+            _metarRepository.GetMetar(_atisStation.Identifier, monitor: true);
+        }
     }
 
     private void OnFsdPositionUpdateTimerElapsed(object? sender, ElapsedEventArgs e)

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -292,28 +292,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 }
                 else
                 {
-                    // If the ATIS is offline, then populate the airport conditions
-                    // and notams for the selected preset.
-                    if (SelectedAtisPreset != null)
+                    // Clear Airport Conditions and NOTAMs
+                    if (AirportConditionsTextDocument != null)
                     {
-                        PopulateAirportConditions();
-                        PopulateNotams();
+                        AirportConditionsTextDocument.Text = "";
                     }
 
-                    // Otherwise, just empty the textboxes.
-                    // This makes it appear as the offline state.
-                    // Only the ATIS letter is still synced for a short period.
-                    else
+                    if (NotamsTextDocument != null)
                     {
-                        if (AirportConditionsTextDocument != null)
-                        {
-                            AirportConditionsTextDocument.Text = "";
-                        }
-
-                        if (NotamsTextDocument != null)
-                        {
-                            NotamsTextDocument.Text = "";
-                        }
+                        NotamsTextDocument.Text = "";
                     }
                 }
             });
@@ -337,25 +324,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     ObservationTime = null;
                     NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;
 
-                    // Populate with the last selected ATIS preset
-                    if (SelectedAtisPreset != null)
+                    // Clear Airport Conditions and NOTAMs
+                    if (AirportConditionsTextDocument != null)
                     {
-                        PopulateAirportConditions();
-                        PopulateNotams();
+                        AirportConditionsTextDocument.Text = "";
                     }
 
-                    // Otherwise, just empty the textboxes.
-                    else
+                    if (NotamsTextDocument != null)
                     {
-                        if (AirportConditionsTextDocument != null)
-                        {
-                            AirportConditionsTextDocument.Text = "";
-                        }
-
-                        if (NotamsTextDocument != null)
-                        {
-                            NotamsTextDocument.Text = "";
-                        }
+                        NotamsTextDocument.Text = "";
                     }
                 });
             }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -901,8 +901,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
         await dlg.ShowDialog(lifetime.MainWindow);
 
-        // Update the free-form text area after the dialog is closed
-        PopulateNotams();
+        if (NetworkConnectionStatus != NetworkConnectionStatus.Observer)
+        {
+            // Update the free-form text area after the dialog is closed
+            PopulateNotams();
+        }
     }
 
     private async Task HandleOpenAirportConditionsDialog()
@@ -954,8 +957,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
         await dlg.ShowDialog(lifetime.MainWindow);
 
-        // Update the free-form text area after the dialog is closed
-        PopulateAirportConditions();
+        if (NetworkConnectionStatus != NetworkConnectionStatus.Observer)
+        {
+            // Update the free-form text area after the dialog is closed
+            PopulateAirportConditions();
+        }
     }
 
     private void OnKillRequestedReceived(object? sender, KillRequestReceived e)
@@ -1254,6 +1260,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             NetworkConnectionStatus = NetworkConnectionStatus.Connected;
             IsNewAtis = false; // Reset to avoid flashing ATIS letter
 
+            PopulateAirportConditions(true);
+            PopulateNotams(true);
+
             // Increase connection count by one
             _sessionManager.CurrentConnectionCount++;
         });
@@ -1513,6 +1522,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                 SelectedAtisPreset = preset;
                 _previousAtisPreset = preset;
+
+                if (NetworkConnectionStatus == NetworkConnectionStatus.Observer)
+                    return;
 
                 PopulateAirportConditions(presetChanged: true);
                 PopulateNotams(presetChanged: true);

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1263,6 +1263,10 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
             if (e.CallsignInuse)
             {
+                // Reset selected preset
+                _previousAtisPreset = null;
+                SelectedAtisPreset = null;
+
                 // Subscribe to ATIS again if we were disconnected due to duplicate callsign
                 SubscribeToAtis();
             }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1301,7 +1301,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             if (SelectedAtisPreset == null)
                 return;
 
-            if (NetworkConnectionStatus is NetworkConnectionStatus.Observer or NetworkConnectionStatus.Disconnected)
+            if (NetworkConnectionStatus != NetworkConnectionStatus.Connected)
                 return;
 
             // Cancel previous request


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Airport conditions and NOTAMs fields are now cleared (instead of repopulated) when the ATIS station is offline or disconnected.
	- Updates to airport conditions and NOTAMs after dialogs are now restricted when in observer mode.
	- Text fields for airport conditions and NOTAMs are refreshed immediately upon network connection.
	- Improved handling of network status and preset changes to prevent unnecessary updates in observer or disconnected states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->