### PR TITLE
[VATIS-132] Save and/or Apply NOTAMs and Airport Conditions

### DIFF
--- a/vATIS.Desktop/Atis/AtisBuilder.cs
+++ b/vATIS.Desktop/Atis/AtisBuilder.cs
@@ -183,14 +183,18 @@ public class AtisBuilder : IAtisBuilder
             var jsonSerialized = JsonSerializer.Serialize(request, SourceGenerationContext.NewDefault.IdsUpdateRequest);
             await _downloader.PostJson(station.IdsEndpoint, jsonSerialized, jwt, cancellationToken);
         }
+        catch (OperationCanceledException)
+        {
+            // Ignore
+        }
         catch (HttpRequestException ex)
         {
-            Log.Error(ex.ToString(), "HttpRequestException updating IDS");
+            Log.Error(ex, "HttpRequestException updating IDS");
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to update IDS");
-            throw new AtisBuilderException($"Failed to Update IDS: " + ex.Message);
+            throw new AtisBuilderException($"Failed to Update IDS: {ex.Message}");
         }
     }
 

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml
@@ -44,26 +44,34 @@
 			<!--Airport Conditions/Notams-->
 			<Grid Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Margin="0,5,0,0" ColumnDefinitions="2*,10,2*" RowDefinitions="Auto,*">
 				<!--Airport Conditions-->
-				<Grid ColumnDefinitions="1*,Auto">
-					<Button Grid.Column="0" Theme="{StaticResource HyperlinkButton}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5" Command="{Binding OpenStaticAirportConditionsDialogCommand, DataType=vm:AtisStationViewModel}">AIRPORT CONDITIONS</Button>
-					<Button Grid.Column="1" Theme="{StaticResource HyperlinkButtonSave}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5"  IsVisible="{Binding HasUnsavedAirportConditions, DataType=vm:AtisStationViewModel, FallbackValue=False}" Command="{Binding SaveAirportConditionsText, DataType=vm:AtisStationViewModel}">★SAVE CHANGES★</Button>
-				</Grid>
+                <Button Grid.Column="0" Grid.Row="0" Theme="{StaticResource HyperlinkButton}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5" Command="{Binding OpenStaticAirportConditionsDialogCommand, DataType=vm:AtisStationViewModel}">AIRPORT CONDITIONS</Button>
 				<editor:TextEditor Name="AirportConditions" Grid.Row="1" Grid.Column="0" Document="{Binding AirportConditionsTextDocument, DataType=vm:AtisStationViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" Padding="4" TextChanged="AirportConditions_OnTextChanged" IsReadOnly="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Observer}}">
 					<Interaction.Behaviors>
 						<behaviors:TextEditorUpperCaseBehavior/>
 						<behaviors:TextEditorCompletionBehavior CompletionData="{Binding ContractionCompletionData, DataType=vm:AtisStationViewModel}"/>
 					</Interaction.Behaviors>
+                    <editor:TextEditor.ContextMenu>
+                        <ContextMenu IsEnabled="{Binding HasUnsavedAirportConditions, DataType=vm:AtisStationViewModel}">
+                            <MenuItem Header="Apply Without Saving" ToolTip.Tip="Temporarily apply changes to the ATIS without saving them to the profile" Command="{Binding ApplyAirportConditionsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:False}"/>
+                            <Separator/>
+                            <MenuItem Header="Save and Apply" ToolTip.Tip="Save changes to the profile and apply them to the ATIS" Command="{Binding ApplyAirportConditionsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
+                        </ContextMenu>
+                    </editor:TextEditor.ContextMenu>
 				</editor:TextEditor>
 				<!--Notams-->
-				<Grid ColumnDefinitions="1*,Auto" Grid.Column="2" Grid.Row="0">
-					<Button Grid.Column="0" Theme="{StaticResource HyperlinkButton}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5" Command="{Binding OpenStaticNotamsDialogCommand, DataType=vm:AtisStationViewModel}">NOTAMS</Button>
-					<Button Grid.Column="1" Theme="{StaticResource HyperlinkButtonSave}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5"  HorizontalAlignment="Right" IsVisible="{Binding HasUnsavedNotams, DataType=vm:AtisStationViewModel, FallbackValue=False}" Command="{Binding SaveNotamsText, DataType=vm:AtisStationViewModel}">★SAVE CHANGES★</Button>
-				</Grid>
+                <Button Grid.Column="2" Grid.Row="0" Theme="{StaticResource HyperlinkButton}" FontWeight="Medium" VerticalAlignment="Center" Margin="0,0,0,5" Command="{Binding OpenStaticNotamsDialogCommand, DataType=vm:AtisStationViewModel}">NOTAMS</Button>
 				<editor:TextEditor Name="NotamText" Grid.Row="1" Grid.Column="2" Document="{Binding NotamsTextDocument, DataType=vm:AtisStationViewModel}" WordWrap="True" ShowLineNumbers="False" HorizontalAlignment="Stretch" FontFamily="{StaticResource Monospace}" Padding="4" TextChanged="NotamText_OnTextChanged" IsReadOnly="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Observer}}">
 					<Interaction.Behaviors>
 						<behaviors:TextEditorUpperCaseBehavior/>
 						<behaviors:TextEditorCompletionBehavior CompletionData="{Binding ContractionCompletionData, DataType=vm:AtisStationViewModel}"/>
 					</Interaction.Behaviors>
+                    <editor:TextEditor.ContextMenu>
+                        <ContextMenu IsEnabled="{Binding HasUnsavedNotams, DataType=vm:AtisStationViewModel}">
+                            <MenuItem Header="Apply Without Saving" ToolTip.Tip="Temporarily apply changes to the ATIS without saving them to the profile" Command="{Binding ApplyNotamsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:False}"/>
+                            <Separator/>
+                            <MenuItem Header="Save and Apply" ToolTip.Tip="Save changes to the profile and apply them to the ATIS" Command="{Binding ApplyNotamsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
+                        </ContextMenu>
+                    </editor:TextEditor.ContextMenu>
 				</editor:TextEditor>
 			</Grid>
 			<!--Bottom Toolbar-->

--- a/vATIS.Desktop/Ui/Controls/Notification/WindowNotificationManager.cs
+++ b/vATIS.Desktop/Ui/Controls/Notification/WindowNotificationManager.cs
@@ -159,6 +159,13 @@ public class WindowNotificationManager : WindowMessageManager
         Action? onClose = null,
         string[]? classes = null)
     {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() =>
+                Show(content, type, expiration, showIcon, showClose, onClick, onClose, classes));
+            return;
+        }
+
         var notificationControl = new NotificationCard
         {
             Content = content,
@@ -194,15 +201,14 @@ public class WindowNotificationManager : WindowMessageManager
                 _hoveredCards--;
         };
 
-        Dispatcher.UIThread.Post(() =>
-        {
-            Items?.Add(notificationControl);
 
-            if (Items?.OfType<NotificationCard>().Count(i => !i.IsClosing) > MaxItems)
-            {
-                Items.OfType<NotificationCard>().First(i => !i.IsClosing).Close();
-            }
-        });
+        Items?.Add(notificationControl);
+
+        if (Items?.OfType<NotificationCard>().Count(i => !i.IsClosing) > MaxItems)
+        {
+            Items.OfType<NotificationCard>().First(i => !i.IsClosing).Close();
+        }
+
 
         if (expiration != TimeSpan.Zero)
         {

--- a/vATIS.Desktop/Ui/Controls/Notification/WindowNotificationManager.cs
+++ b/vATIS.Desktop/Ui/Controls/Notification/WindowNotificationManager.cs
@@ -201,14 +201,13 @@ public class WindowNotificationManager : WindowMessageManager
                 _hoveredCards--;
         };
 
-
         Items?.Add(notificationControl);
-
-        if (Items?.OfType<NotificationCard>().Count(i => !i.IsClosing) > MaxItems)
+        if (Items is { } collection)
         {
-            Items.OfType<NotificationCard>().First(i => !i.IsClosing).Close();
+            var active = collection.OfType<NotificationCard>().Where(i => !i.IsClosing).ToList();
+            if (active.Count > MaxItems)
+                active.First().Close();
         }
-
 
         if (expiration != TimeSpan.Zero)
         {

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -70,6 +70,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private readonly MetarDecoder _metarDecoder = new();
     private readonly CompositeDisposable _disposables = [];
     private readonly SemaphoreSlim _voiceRequestLock = new(1, 1);
+    private readonly string? _identifier;
     private CancellationTokenSource _voiceRequestCts = new();
     private CancellationTokenSource _selectedPresetCts = new();
     private CancellationTokenSource _voiceRecordAtisCts = new();
@@ -81,7 +82,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private int _notamFreeTextOffset;
     private int _airportConditionsFreeTextOffset;
     private string? _id;
-    private string? _identifier;
     private string? _tabText;
     private int _ordinal;
     private char _atisLetter;
@@ -378,11 +378,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets the notification manager.
-    /// </summary>
-    public WindowNotificationManager? NotificationManager { get; }
-
-    /// <summary>
     /// Gets or sets the collection of read-only airport condition text segments.
     /// </summary>
     public TextSegmentCollection<TextSegment> ReadOnlyAirportConditions { get; set; }
@@ -441,10 +436,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     public ReactiveCommand<bool, Unit> ApplyAirportConditionsCommand { get; }
 
     /// <summary>
-    /// Gets the command that sets the ATIS letter. Used with fetching real-world D-ATIS letter.
     /// Gets the command that updates the ATIS with the changed NOTAMs.
     /// </summary>
-    public ReactiveCommand<char, Unit> SetAtisLetterCommand { get; }
     /// <remarks>
     /// Pass <c>true</c> to save the changes to the profile; <c>false</c> to apply them temporarily.
     /// </remarks>
@@ -465,12 +458,12 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets the identifier associated with the ATIS station.
+    /// Gets the identifier associated with the ATIS station.
     /// </summary>
     public string? Identifier
     {
         get => _identifier;
-        set => this.RaiseAndSetIfChanged(ref _identifier, value);
+        private init => this.RaiseAndSetIfChanged(ref _identifier, value);
     }
 
     /// <summary>
@@ -615,15 +608,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether text-to-speech functionality is enabled.
-    /// </summary>
-    public bool UseTexToSpeech
-    {
-        get => _useTexToSpeech;
-        set => this.RaiseAndSetIfChanged(ref _useTexToSpeech, value);
-    }
-
-    /// <summary>
     /// Gets or sets the network connection status of the ATIS station.
     /// </summary>
     public NetworkConnectionStatus NetworkConnectionStatus
@@ -671,6 +655,16 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _ordinal;
         set => this.RaiseAndSetIfChanged(ref _ordinal, value);
+    }
+
+    private ReactiveCommand<char, Unit> SetAtisLetterCommand { get; }
+
+    private WindowNotificationManager? NotificationManager { get; }
+
+    private bool UseTexToSpeech
+    {
+        get => _useTexToSpeech;
+        set => this.RaiseAndSetIfChanged(ref _useTexToSpeech, value);
     }
 
     /// <summary>

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1699,15 +1699,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }
         else
         {
-            if (!string.IsNullOrEmpty(_previousFreeTextNotams))
+            var textToInsert = !string.IsNullOrEmpty(_previousFreeTextNotams)
+                ? _previousFreeTextNotams.Trim()
+                : SelectedAtisPreset?.Notams?.Trim();
+
+            if (!string.IsNullOrEmpty(textToInsert))
             {
-                NotamsTextDocument.Insert(0, _previousFreeTextNotams.Trim() + " ");
-                _notamFreeTextOffset = _previousFreeTextNotams.Trim().Length + 1;
-            }
-            else if (!string.IsNullOrEmpty(SelectedAtisPreset.Notams))
-            {
-                NotamsTextDocument.Insert(0, SelectedAtisPreset.Notams.Trim() + " ");
-                _notamFreeTextOffset = SelectedAtisPreset.Notams.Trim().Length + 1;
+                var hasStaticDefinitions = staticDefinitions.Count > 0;
+                NotamsTextDocument.Insert(0, hasStaticDefinitions ? textToInsert + " " : textToInsert);
+                _notamFreeTextOffset = textToInsert.Length + (hasStaticDefinitions ? 1 : 0);
             }
 
             // Insert static definitions after free-text
@@ -1788,15 +1788,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         }
         else
         {
-            if (!string.IsNullOrEmpty(_previousFreeTextAirportConditions))
+            var textToInsert = !string.IsNullOrEmpty(_previousFreeTextAirportConditions)
+                ? _previousFreeTextAirportConditions.Trim()
+                : SelectedAtisPreset?.AirportConditions?.Trim();
+
+            if (!string.IsNullOrEmpty(textToInsert))
             {
-                AirportConditionsTextDocument.Insert(0, _previousFreeTextAirportConditions.Trim() + " ");
-                _airportConditionsFreeTextOffset = _previousFreeTextAirportConditions.Trim().Length + 1;
-            }
-            else if (!string.IsNullOrEmpty(SelectedAtisPreset.AirportConditions))
-            {
-                AirportConditionsTextDocument.Insert(0, SelectedAtisPreset.AirportConditions.Trim() + " ");
-                _airportConditionsFreeTextOffset = SelectedAtisPreset.AirportConditions.Trim().Length + 1;
+                var hasStaticDefinitions = staticDefinitions.Count > 0;
+                AirportConditionsTextDocument.Insert(0, hasStaticDefinitions ? textToInsert + " " : textToInsert);
+                _airportConditionsFreeTextOffset = textToInsert.Length + (hasStaticDefinitions ? 1 : 0);
             }
 
             // Insert static definitions after free-text

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -617,7 +617,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets the collection of contraction completion data utilized for auto-completion.
+    /// Gets or sets the collection of contraction completion data used for auto-completion.
     /// </summary>
     public List<ICompletionData> ContractionCompletionData
     {
@@ -1442,7 +1442,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Publishes the current ATIS information to connected websocket clients.
     /// </summary>
-    /// <param name="session">The connected client to publish the data to. If omitted or null the data is broadcast to all connected clients.</param>
+    /// <param name="session">The connected client to publish the data to.
+    /// If omitted or null, the data is broadcast to all connected clients.</param>
     /// <returns>A task.</returns>
     private async Task PublishAtisToWebsocket(ClientMetadata? session = null)
     {
@@ -1892,7 +1893,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void OnGetAtisReceived(object? sender, GetAtisReceived e)
     {
-        // Throw exception to websocket client if both ID and Station are provided.
+        // Throw exception to the websocket client if both ID and Station are provided.
         if (!string.IsNullOrEmpty(e.StationId) && !string.IsNullOrEmpty(e.Station))
         {
             throw new Exception("Cannot provide both Id and Station.");
@@ -1917,7 +1918,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void OnAcknowledgeAtisUpdateReceived(object? sender, AcknowledgeAtisUpdateReceived e)
     {
-        // Throw exception to websocket client if both ID and Station are provided.
+        // Throw exception to the websocket client if both ID and Station are provided.
         if (!string.IsNullOrEmpty(e.StationId) && !string.IsNullOrEmpty(e.Station))
         {
             throw new Exception("Cannot provide both Id and Station.");


### PR DESCRIPTION
Add context menu with options to apply changes or save and apply changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added right-click context menus to the Airport Conditions and NOTAMs editors, allowing users to "Apply Without Saving" or "Save and Apply" changes when edits are present.
- **Refactor**
	- Simplified the UI by removing visible save buttons and moving save/apply actions to context menus.
	- Centralized ATIS building and publishing logic for improved consistency and reliability.
	- Improved notification display handling to ensure proper UI thread execution and streamlined notification management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->