### PR TITLE
[VATIS-151] Improve blinking ATIS letter notification

### DIFF
--- a/vATIS.Desktop/Events/AcknowledgeAllAtisUpdates.cs
+++ b/vATIS.Desktop/Events/AcknowledgeAllAtisUpdates.cs
@@ -1,0 +1,6 @@
+namespace Vatsim.Vatis.Events;
+
+/// <summary>
+/// Represents an event that acknowledges all pending ATIS updates.
+/// </summary>
+public class AcknowledgeAllAtisUpdates : IEvent;

--- a/vATIS.Desktop/Events/AcknowledgeAllAtisUpdates.cs
+++ b/vATIS.Desktop/Events/AcknowledgeAllAtisUpdates.cs
@@ -1,3 +1,8 @@
+// <copyright file="AcknowledgeAllAtisUpdates.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
 namespace Vatsim.Vatis.Events;
 
 /// <summary>

--- a/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
@@ -48,7 +48,7 @@ public class BlinkingTextBehavior : Behavior<Control>
     /// </summary>
     // ReSharper disable once MemberCanBePrivate.Global
     public static readonly StyledProperty<TimeSpan> BlinkDurationProperty =
-        AvaloniaProperty.Register<BlinkingTextBehavior, TimeSpan>(nameof(BlinkDuration), TimeSpan.FromSeconds(30));
+        AvaloniaProperty.Register<BlinkingTextBehavior, TimeSpan>(nameof(BlinkDuration), TimeSpan.FromSeconds(60));
 
     private static readonly List<BlinkingTextBehavior> s_instances = [];
     private static bool s_isBlinking;
@@ -89,7 +89,7 @@ public class BlinkingTextBehavior : Behavior<Control>
 
     /// <summary>
     /// Gets or sets the duration that the control will blink before reverting
-    /// to its original foreground color. The default is 30 seconds.
+    /// to its original foreground color.
     /// </summary>
     public TimeSpan BlinkDuration
     {

--- a/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
@@ -120,11 +120,15 @@ public class BlinkingTextBehavior : Behavior<Control>
                 var token = _blinkCts.Token;
 
                 var weakRef = new WeakReference<BlinkingTextBehavior>(this);
+
+                // Capture BlinkDuration from UI thread
+                var blinkDuration = BlinkDuration;
+
                 Task.Run(async () =>
                 {
                     try
                     {
-                        await Task.Delay(BlinkDuration, token);
+                        await Task.Delay(blinkDuration, token);
 
                         if (!token.IsCancellationRequested && weakRef.TryGetTarget(out var target))
                         {

--- a/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
@@ -14,32 +14,32 @@ using Avalonia.Xaml.Interactivity;
 namespace Vatsim.Vatis.Ui.Behaviors;
 
 /// <summary>
-/// Provides a behavior that alternates the foreground color of a control
-/// between two specified colors, creating a blinking effect.
+/// A behavior that enables a blinking text effect on supported Avalonia controls.
+/// The foreground color alternates between <see cref="BlinkOnColor"/> and <see cref="BlinkOffColor"/> while <see cref="IsBlinking"/> is true.
 /// </summary>
 public class BlinkingTextBehavior : Behavior<Control>
 {
     /// <summary>
-    /// Identifies the <see cref="IsBlinkingProperty"/> dependency property, determining whether
-    /// the associated control should have its text alternate between two colors, creating a blinking effect.
+    /// Identifies the <see cref="IsBlinking"/> property.
     /// </summary>
+    // ReSharper disable once MemberCanBePrivate.Global
     public static readonly StyledProperty<bool> IsBlinkingProperty =
         AvaloniaProperty.Register<BlinkingTextBehavior, bool>(nameof(IsBlinking));
 
     /// <summary>
-    /// Identifies the <see cref="Color1Property"/> dependency property, specifying
-    /// the first foreground color used by the associated control when creating a blinking effect.
+    /// Identifies the <see cref="BlinkOnColor"/> property.
     /// </summary>
-    public static readonly StyledProperty<IBrush> Color1Property =
-        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(Color1), Brushes.Aqua);
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<IBrush> BlinkOnColorProperty =
+        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(BlinkOnColor),
+            new SolidColorBrush(Color.FromRgb(255, 204, 1)));
 
     /// <summary>
-    /// Identifies the <see cref="Color2Property"/> dependency property, specifying
-    /// the second foreground color used by the associated control when creating a blinking effect.
+    /// Identifies the <see cref="BlinkOffColor"/> property.
     /// </summary>
-    public static readonly StyledProperty<IBrush> Color2Property =
-        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(Color2),
-            new SolidColorBrush(Color.FromRgb(255, 204, 1)));
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<IBrush> BlinkOffColorProperty =
+        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(BlinkOffColor), Brushes.Aqua);
 
     private static readonly List<BlinkingTextBehavior> s_instances = [];
     private static bool s_isBlinking;
@@ -51,8 +51,7 @@ public class BlinkingTextBehavior : Behavior<Control>
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the associated control
-    /// should alternate its text color between two specified colors, creating a blinking effect.
+    /// Gets or sets a value indicating whether the blinking effect is active.
     /// </summary>
     public bool IsBlinking
     {
@@ -61,23 +60,21 @@ public class BlinkingTextBehavior : Behavior<Control>
     }
 
     /// <summary>
-    /// Gets or sets the first foreground color used by the associated control
-    /// when creating a blinking effect.
+    /// Gets or sets the brush used when the text is in the "on" blink state.
     /// </summary>
-    public IBrush Color1
+    public IBrush BlinkOnColor
     {
-        get => GetValue(Color1Property);
-        set => SetValue(Color1Property, value);
+        get => GetValue(BlinkOnColorProperty);
+        set => SetValue(BlinkOnColorProperty, value);
     }
 
     /// <summary>
-    /// Gets or sets the second foreground color used by the associated control
-    /// when creating a blinking effect.
+    /// Gets or sets the brush used when the text is in the "off" blink state.
     /// </summary>
-    public IBrush Color2
+    public IBrush BlinkOffColor
     {
-        get => GetValue(Color2Property);
-        set => SetValue(Color2Property, value);
+        get => GetValue(BlinkOffColorProperty);
+        set => SetValue(BlinkOffColorProperty, value);
     }
 
     /// <inheritdoc/>
@@ -87,7 +84,8 @@ public class BlinkingTextBehavior : Behavior<Control>
 
         if (AssociatedObject is not null)
         {
-            _originalBrush = GetForeground(AssociatedObject);
+            // Delay grabbing the original brush until it's actually set by the binding
+            AssociatedObject.AttachedToVisualTree += (_, _) => _originalBrush = GetForeground(AssociatedObject);
             s_instances.Add(this);
         }
     }
@@ -114,7 +112,7 @@ public class BlinkingTextBehavior : Behavior<Control>
             {
                 if (instance.IsBlinking)
                 {
-                    SetForeground(instance.AssociatedObject, s_isBlinking ? instance.Color1 : instance.Color2);
+                    SetForeground(instance.AssociatedObject, s_isBlinking ? instance.BlinkOnColor : instance.BlinkOffColor);
                 }
                 else
                 {

--- a/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/BlinkingTextBehavior.cs
@@ -33,8 +33,7 @@ public class BlinkingTextBehavior : Behavior<Control>
     /// </summary>
     // ReSharper disable once MemberCanBePrivate.Global
     public static readonly StyledProperty<IBrush> BlinkOnColorProperty =
-        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(BlinkOnColor),
-            new SolidColorBrush(Color.FromRgb(255, 204, 1)));
+        AvaloniaProperty.Register<BlinkingTextBehavior, IBrush>(nameof(BlinkOnColor), Brushes.Gold);
 
     /// <summary>
     /// Identifies the <see cref="BlinkOffColor"/> property.

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml
@@ -21,7 +21,7 @@
 			<!--Atis Letter-->
 			<Button Name="AtisLetter" IsVisible="{Binding !IsAtisLetterInputMode, DataType=vm:AtisStationViewModel}" CornerRadius="3" Classes="AtisLetter" Foreground="White" Grid.Column="0" Grid.Row="0" Content="{Binding AtisLetter, DataType=vm:AtisStationViewModel, FallbackValue=A}" IsEnabled="True" FontFamily="{DynamicResource Monospace}">
 				<Interaction.Behaviors>
-					<behaviors:BlinkingTextBehavior IsEnabled="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}" IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel, FallbackValue=False}"/>
+                    <behaviors:BlinkingTextBehavior IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel, FallbackValue=False, Mode=TwoWay}" BlinkOffColor="White"/>
 				</Interaction.Behaviors>
 			</Button>
 			<TextBox Name="TypeAtisLetter" IsVisible="{Binding IsAtisLetterInputMode, DataType=vm:AtisStationViewModel}" Grid.Column="0" Grid.Row="0" Theme="{StaticResource DarkTextBox}" Height="85" FontSize="60" FontWeight="Medium" FontFamily="{StaticResource Monospace}" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" MaxLength="1" AcceptsReturn="False" TextWrapping="NoWrap" ScrollViewer.VerticalScrollBarVisibility="Hidden">

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml.cs
@@ -183,18 +183,24 @@ public partial class AtisStationView : ReactiveUserControl<AtisStationViewModel>
             if (ViewModel == null)
                 return;
 
-            if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
-                return;
-
-            // If the shift key is held down it likely means the user is trying to
+            // If the shift key is held down, it likely means the user is trying to
             // shift + double click to get into edit mode, so don't advance
             // the letter.
-            if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
+            if ((e.KeyModifiers & KeyModifiers.Shift) != 0 &&
+                ViewModel.NetworkConnectionStatus != NetworkConnectionStatus.Observer)
             {
                 return;
             }
 
-            await ViewModel.AcknowledgeOrIncrementAtisLetterCommand.Execute();
+            if (ViewModel.NetworkConnectionStatus == NetworkConnectionStatus.Observer)
+            {
+                await ViewModel.AcknowledgeAtisUpdateCommand.Execute();
+            }
+            else
+            {
+                // Only allow incrementing the ATIS letter for connected station.
+                await ViewModel.AcknowledgeOrIncrementAtisLetterCommand.Execute();
+            }
         }
         catch (Exception ex)
         {

--- a/vATIS.Desktop/Ui/Controls/CustomTabItem.axaml
+++ b/vATIS.Desktop/Ui/Controls/CustomTabItem.axaml
@@ -8,6 +8,7 @@
 	<converter:AtisLetterVisibleConverter x:Key="AtisLetterVisibleConverter"/>
     <converter:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
     <converter:AtisLetterColorConverter x:Key="AtisLetterColorConverter"/>
+    <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Coral"/>
 	<ControlTheme x:Key="{x:Type controls:CustomTabItem}" TargetType="controls:CustomTabItem">
 		<Setter Property="Foreground" Value="#848484"/>
 		<Setter Property="Background" Value="#323232"/>
@@ -48,7 +49,7 @@
 								   IsVisible="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource AtisLetterVisibleConverter}}"
 								   Margin="5 0 0 0">
 							<Interaction.Behaviors>
-								<behaviors:BlinkingTextBehavior IsEnabled="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static network:NetworkConnectionStatus.Connected}}" IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel}" />
+								<behaviors:BlinkingTextBehavior IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel, Mode=TwoWay}" BlinkOffColor="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource ConnectionStatusToBrush}, ConverterParameter={x:Static network:NetworkConnectionStatus.Connected}}" />
 							</Interaction.Behaviors>
 						</TextBlock>
 					</StackPanel>

--- a/vATIS.Desktop/Ui/Controls/CustomTabItem.axaml
+++ b/vATIS.Desktop/Ui/Controls/CustomTabItem.axaml
@@ -8,7 +8,7 @@
 	<converter:AtisLetterVisibleConverter x:Key="AtisLetterVisibleConverter"/>
     <converter:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
     <converter:AtisLetterColorConverter x:Key="AtisLetterColorConverter"/>
-    <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Coral"/>
+    <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Tomato"/>
 	<ControlTheme x:Key="{x:Type controls:CustomTabItem}" TargetType="controls:CustomTabItem">
 		<Setter Property="Foreground" Value="#848484"/>
 		<Setter Property="Background" Value="#323232"/>

--- a/vATIS.Desktop/Ui/Converters/AtisLetterColorConverter.cs
+++ b/vATIS.Desktop/Ui/Converters/AtisLetterColorConverter.cs
@@ -24,7 +24,7 @@ public class AtisLetterColorConverter : IValueConverter
             return status switch
             {
                 NetworkConnectionStatus.Connected => Brushes.Aqua,
-                NetworkConnectionStatus.Observer => Brushes.Coral,
+                NetworkConnectionStatus.Observer => Brushes.Tomato,
                 _ => Brushes.Aqua
             };
         }

--- a/vATIS.Desktop/Ui/Converters/EnumToBrushConverter.cs
+++ b/vATIS.Desktop/Ui/Converters/EnumToBrushConverter.cs
@@ -1,0 +1,49 @@
+// <copyright file="EnumToBrushConverter.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace Vatsim.Vatis.Ui.Converters;
+
+/// <summary>
+/// Converts an enumeration value to a brush color based on whether it matches a specified target value.
+/// </summary>
+public class EnumToBrushConverter : IValueConverter
+{
+    /// <summary>
+    /// Gets or sets the brush to use when the bound enum value matches the specified converter parameter.
+    /// </summary>
+    public IBrush Match { get; set; } = Brushes.White;
+
+    /// <summary>
+    /// Gets or sets the brush to use when the bound enum value does not match the specified converter parameter.
+    /// </summary>
+    public IBrush NoMatch { get; set; } = Brushes.Black;
+
+    /// <summary>
+    /// Converts an enum value to a brush based on whether it matches the provided parameter string.
+    /// </summary>
+    /// <param name="value">The enum value to evaluate.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The string representation of the enum value to match against.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>The <see cref="Match"/> brush if the enum value matches the parameter; otherwise, <see cref="NoMatch"/>.</returns>
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+            return NoMatch;
+
+        return value.Equals(parameter) ? Match : NoMatch;
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -328,6 +328,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     Metar = null;
                     ObservationTime = null;
                     NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;
+                    IsNewAtis = false;
 
                     // Clear Airport Conditions and NOTAMs
                     if (AirportConditionsTextDocument != null)

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -27,7 +27,7 @@
         Title="vATIS">
     <Window.Resources>
         <converter:AtisLetterColorConverter x:Key="AtisLetterColorConverter"/>
-        <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Coral"/>
+        <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Tomato"/>
         <DataTemplate x:Key="AtisLetterTemplate">
             <TextBlock
                 Name="AtisLetter"

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -38,7 +38,7 @@
                 Foreground="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource AtisLetterColorConverter}, FallbackValue=Aqua}" Cursor="Hand">
                 <Interaction.Behaviors>
                     <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="AtisLetter">
-                        <InvokeCommandAction Command="{Binding AcknowledgeAtisUpdateCommand, DataType=vm:AtisStationViewModel}" />
+                        <InvokeCommandAction Command="{Binding AcknowledgeAtisUpdateCommand, DataType=vm:AtisStationViewModel}" PassEventArgsToCommand="True" />
                     </RoutedEventTriggerBehavior>
                     <behaviors:BlinkingTextBehavior IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel, Mode=TwoWay}" BlinkOffColor="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource ConnectionStatusToBrush}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}"/>
                 </Interaction.Behaviors>

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -27,6 +27,7 @@
         Title="vATIS">
     <Window.Resources>
         <converter:AtisLetterColorConverter x:Key="AtisLetterColorConverter"/>
+        <converter:EnumToBrushConverter x:Key="ConnectionStatusToBrush" Match="Aqua" NoMatch="Coral"/>
         <DataTemplate x:Key="AtisLetterTemplate">
             <TextBlock
                 Name="AtisLetter"
@@ -39,9 +40,7 @@
                     <RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.PointerPressedEvent}" SourceInteractive="AtisLetter">
                         <InvokeCommandAction Command="{Binding AcknowledgeAtisUpdateCommand, DataType=vm:AtisStationViewModel}" />
                     </RoutedEventTriggerBehavior>
-                    <behaviors:BlinkingTextBehavior
-                        IsEnabled="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}"
-                        IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel}" />
+                    <behaviors:BlinkingTextBehavior IsBlinking="{Binding IsNewAtis, DataType=vm:AtisStationViewModel, Mode=TwoWay}" BlinkOffColor="{Binding NetworkConnectionStatus, DataType=vm:AtisStationViewModel, Converter={StaticResource ConnectionStatusToBrush}, ConverterParameter={x:Static networking:NetworkConnectionStatus.Connected}}"/>
                 </Interaction.Behaviors>
             </TextBlock>
         </DataTemplate>


### PR DESCRIPTION
- Fixed an issue where observed ATIS letters would not blink when the ATIS was updated.
- Added a maximum blink duration for ATIS letters; they will now blink for up to 60 seconds before automatically acknowledging themselves.
- Added support for acknowledging all pending ATIS updates (blinking letters) in the mini-window by middle or right-clicking on any ATIS letter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new event for acknowledging all pending ATIS updates.
  - Added a converter to dynamically map connection status to color in the user interface.

- **Enhancements**
  - Improved blinking text behavior with new properties for blink duration and customizable blink colors.
  - Blinking effect now automatically stops after a set duration.
  - Blinking and color behavior now adapts based on network connection status.

- **User Interface Updates**
  - Refined color schemes for ATIS status indicators.
  - Simplified and clarified UI bindings for blinking text and ATIS letter controls.
  - Enhanced tap and click handling for ATIS letter interactions, with improved observer and shift-key logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->