### PR TITLE
Hide Sandbox tab if using external ATIS generator

### DIFF
--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
@@ -100,7 +100,7 @@
 						<TabItem Header="Contractions">
 							<views:ContractionsView DataContext="{Binding ContractionsViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
-						<TabItem Header="Sandbox" Name="SandboxTab">
+						<TabItem Header="Sandbox" Name="SandboxTab" IsVisible="False">
 							<views:SandboxView DataContext="{Binding SandboxViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
 					</TabControl>

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
@@ -100,7 +100,7 @@
 						<TabItem Header="Contractions">
 							<views:ContractionsView DataContext="{Binding ContractionsViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
-						<TabItem Header="Sandbox">
+						<TabItem Header="Sandbox" Name="SandboxTab">
 							<views:SandboxView DataContext="{Binding SandboxViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
 					</TabControl>

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
@@ -40,7 +40,20 @@ public partial class AtisConfigurationWindow : ReactiveWindow<AtisConfigurationW
         {
             var index = Stations.Items.IndexOf(station);
             Stations.SelectedIndex = index;
+            SandboxTab.IsVisible = false;
         });
+
+        this.WhenAnyValue(x => x.ViewModel!.PresetsViewModel!.SelectedPreset).Subscribe(preset =>
+        {
+            if (preset != null)
+            {
+                SandboxTab.IsVisible = preset.ExternalGenerator is { Enabled: false };
+            }
+        });
+
+        this.WhenAnyValue(x => x.ViewModel!.PresetsViewModel!.UseExternalAtisGenerator)
+            .Skip(1)
+            .Subscribe(useExternalGenerator => { SandboxTab.IsVisible = !useExternalGenerator; });
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The visibility of the Sandbox tab is now dynamically controlled based on selected presets and external generator settings, providing a more responsive and context-aware user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->