### PR TITLE
Fix presets change tracker reset when switching stations

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -893,6 +893,8 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             return;
         }
 
+        _changeTracker.ResetChanges();
+
         SelectedStation = station;
         Presets = new ObservableCollection<AtisPreset>(station.Presets);
         UseExternalAtisGenerator = false;
@@ -910,8 +912,6 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
         NativeAudio.StopBufferPlayback();
 
         PopulateContractions();
-
-        _changeTracker.ResetChanges();
     }
 
     private void PopulateContractions()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the timing of resetting changes during preset updates to improve update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->