### PR TITLE
Update ATIS configuration Sandbox tab

### DIFF
--- a/vATIS.Desktop/Events/StationPresetsChanged.cs
+++ b/vATIS.Desktop/Events/StationPresetsChanged.cs
@@ -6,7 +6,7 @@
 namespace Vatsim.Vatis.Events;
 
 /// <summary>
-/// Represents an event that is raised when station presets are changed.
+/// Represents an event raised when station presets are changed.
 /// </summary>
 /// <param name="Id">The station ID.</param>
 public record StationPresetsChanged(string Id) : IEvent;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/PresetsViewModel.cs
@@ -459,6 +459,11 @@ public class PresetsViewModel : ReactiveViewModelBase, IDisposable
             _profileRepository.Save(_sessionManager.CurrentProfile);
         }
 
+        if (SelectedStation != null)
+        {
+            EventBus.Instance.Publish(new StationPresetsChanged(SelectedStation.Id));
+        }
+
         hasErrors = false;
         return _changeTracker.ApplyChangesIfNeeded();
     }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/SandboxViewModel.cs
@@ -111,7 +111,7 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
         {
             if (evt.Id == SelectedStation?.Id)
             {
-                Presets = new ObservableCollection<AtisPreset>(SelectedStation.Presets);
+                Presets = [.. SelectedStation.Presets.Where(p => p.ExternalGenerator is not { Enabled: true })];
             }
         }));
         _disposables.Add(EventBus.Instance.Subscribe<ContractionsUpdated>(evt =>
@@ -342,7 +342,7 @@ public class SandboxViewModel : ReactiveViewModelBase, IDisposable
 
         SelectedPreset = null;
         SelectedStation = station;
-        Presets = new ObservableCollection<AtisPreset>(station.Presets);
+        Presets = [.. station.Presets.Where(p => p.ExternalGenerator is not { Enabled: true })];
         SandboxMetar = "";
         HasUnsavedAirportConditions = false;
         HasUnsavedNotams = false;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -247,7 +247,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         {
             if (evt.Id == AtisStation.Id)
             {
-                AtisPresetList = new ObservableCollection<AtisPreset>(AtisStation.Presets.OrderBy(x => x.Ordinal));
+                AtisPresetList = [.. AtisStation.Presets.OrderBy(x => x.Ordinal)];
             }
         }));
         _disposables.Add(EventBus.Instance.Subscribe<ContractionsUpdated>(evt =>

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
@@ -100,7 +100,7 @@
 						<TabItem Header="Contractions">
 							<views:ContractionsView DataContext="{Binding ContractionsViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
-						<TabItem Header="Sandbox" Name="SandboxTab" IsVisible="False">
+						<TabItem Header="Sandbox">
 							<views:SandboxView DataContext="{Binding SandboxViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
 					</TabControl>

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -37,27 +36,10 @@ public partial class AtisConfigurationWindow : ReactiveWindow<AtisConfigurationW
         ViewModel?.Initialize(this);
         Closed += OnClosed;
 
-        this.WhenActivated(disposable =>
+        this.WhenAnyValue(x => x.ViewModel!.SelectedAtisStation).Subscribe(station =>
         {
-            if (ViewModel == null)
-                return;
-
-            ViewModel.WhenAnyValue(x => x.SelectedAtisStation).Subscribe(station =>
-            {
-                var index = Stations.Items.IndexOf(station);
-                Stations.SelectedIndex = index;
-                SandboxTab.IsVisible = false;
-            }).DisposeWith(disposable);
-
-            ViewModel.PresetsViewModel?.WhenAnyValue(x => x.SelectedPreset).WhereNotNull().Subscribe(preset =>
-            {
-                SandboxTab.IsVisible = preset.ExternalGenerator is { Enabled: false };
-            }).DisposeWith(disposable);
-
-            ViewModel.PresetsViewModel?.WhenAnyValue(x => x.UseExternalAtisGenerator).Skip(1).Subscribe(value =>
-            {
-                SandboxTab.IsVisible = !value;
-            }).DisposeWith(disposable);
+            var index = Stations.Items.IndexOf(station);
+            Stations.SelectedIndex = index;
         });
     }
 


### PR DESCRIPTION
Update the sandbox tab to only show presets not configured to use external ATIS generator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Sandbox" tab is now visible by default in the ATIS Configuration window.

- **Bug Fixes**
  - Presets lists now exclude those with an enabled external generator, improving preset filtering and display accuracy.

- **Refactor**
  - Improved how preset lists are updated and displayed for stations, resulting in more efficient and streamlined updates.
  - Simplified the logic for updating station selection and removed unnecessary visibility toggling for the "Sandbox" tab.

- **Documentation**
  - Minor rewording of internal event descriptions for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->