### PR TITLE
Disable mouse wheel for non-navigable combobox

### DIFF
--- a/vATIS.Desktop/Ui/Controls/NonNavigableComboBox.cs
+++ b/vATIS.Desktop/Ui/Controls/NonNavigableComboBox.cs
@@ -10,12 +10,18 @@ using Avalonia.Input;
 namespace Vatsim.Vatis.Ui.Controls;
 
 /// <summary>
-/// Represents a customized ComboBox that disables navigation using the up and down arrow keys.
+/// Represents a customized ComboBox that disables navigation using the up and down arrow keys and mouse wheel.
 /// </summary>
 public class NonNavigableComboBox : ComboBox
 {
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(ComboBox);
+
+    /// <inheritdoc />
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        e.Handled = true;
+    }
 
     /// <inheritdoc/>
     protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mouse wheel navigation is now disabled in the combo box, preventing accidental selection changes via the mouse wheel.

- **Documentation**
  - Updated component description to clarify that both keyboard and mouse wheel navigation are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->