### PR TITLE
[VATIS-190] Add text template variable to print the type of observation

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/ObservationTimeNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/ObservationTimeNode.cs
@@ -16,6 +16,8 @@ namespace Vatsim.Vatis.Atis.Nodes;
 public class ObservationTimeNode : BaseNode<string>
 {
     private const string SpecialText = "SPECIAL";
+    private const string SpeciText = "SPECI";
+    private const string MetarText = "METAR";
     private bool _isSpecialAtis;
 
     /// <inheritdoc/>
@@ -57,6 +59,7 @@ public class ObservationTimeNode : BaseNode<string>
         format = Regex.Replace(format, "{hour}", $"{metarHour:00}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{minute}", $"{metarMinute:00}", RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{special}", _isSpecialAtis ? SpecialText : "", RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{type}", _isSpecialAtis ? SpeciText : MetarText, RegexOptions.IgnoreCase);
 
         return format;
     }

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -80,6 +80,13 @@
 								CommandParameter="{Binding $self.Content}">
 								{special}
 							</Button>
+                            <Button
+                                Theme="{StaticResource DarkVariable}"
+                                ToolTip.Tip="Inserts the word &quot;SPECI&quot; or &quot;METAR&quot; based on whether the observation is considered special (if the observation time is different from the Routine Observation Time). This variable is for the text template only."
+                                Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
+                                CommandParameter="{Binding $self.Content}">
+                                {type}
+                            </Button>
 						</StackPanel>
 					</StackPanel>
 				</groupBox:GroupBoxControl>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new template variable that dynamically inserts either "SPECI" or "METAR" in observation time formatting, based on observation type.
  - Introduced a new button in the Observation Time section to easily insert this variable into templates.
- **User Interface**
  - Enhanced the template editor with an additional button for the new observation type variable, complete with tooltip guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->