### PR TITLE
[VATIS-189] Add support custom spoken RVR tendency values

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
@@ -121,7 +121,7 @@ public class RunwayVisualRangeNode : BaseNode<RunwayVisualRange>
                 _ => ""
             };
 
-            if (tendency != null)
+            if (!string.IsNullOrEmpty(tendency))
             {
                 result.Add(tendency);
             }

--- a/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
@@ -87,7 +87,7 @@ public class RunwayVisualRangeNode : BaseNode<RunwayVisualRange>
                     var maxVis = int.Parse(match.Groups[6].Value);
 
                     result.Add(match.Groups[3].Value == "M"
-                        ? $"variable from less than {minVis.ToGroupForm()} to greater than{maxVis.ToGroupForm()}"
+                        ? $"variable from less than {minVis.ToGroupForm()} to greater than {maxVis.ToGroupForm()}"
                         : $"{minVis.ToGroupForm()} variable to greater than {maxVis.ToGroupForm()}");
                     break;
                 }

--- a/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/RunwayVisualRangeNode.cs
@@ -43,85 +43,90 @@ public class RunwayVisualRangeNode : BaseNode<RunwayVisualRange>
         {
             var result = new List<string>();
 
-            if (rvr.RawValue != null)
+            if (rvr.RawValue == null)
             {
-                var match = Regex.Match(rvr.RawValue, @"^R([0-3]{1}\d{1})(L|C|R)?\/(M|P)?(\d{4})(V|VP)?(\d{4})?(FT)?(?:\/?(U|D|N))?$");
+                continue;
+            }
 
-                if (match.Success)
+            var match = Regex.Match(rvr.RawValue,
+                @"^R([0-3]{1}\d{1})(L|C|R)?\/(M|P)?(\d{4})(V|VP)?(\d{4})?(FT)?(?:\/?(U|D|N))?$");
+
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            acars.Add(rvr.RawValue);
+
+            var rwyNumber = match.Groups[1].Value;
+
+            var rwyDesignator = match.Groups[2].Value switch
+            {
+                "L" => "left",
+                "R" => "right",
+                "C" => "center",
+                _ => ""
+            };
+
+            switch (match.Groups[5].Value)
+            {
+                case "V":
                 {
-                    acars.Add(rvr.RawValue);
+                    var minVis = int.Parse(match.Groups[4].Value);
+                    var maxVis = int.Parse(match.Groups[6].Value);
 
-                    var rwyNumber = match.Groups[1].Value;
-                    var rwyDesignator = "";
+                    result.Add(match.Groups[3].Value == "M"
+                        ? $"variable from less than {minVis.ToGroupForm()} to {maxVis.ToGroupForm()}"
+                        : $"variable between {minVis.ToGroupForm()} and {maxVis.ToGroupForm()}");
+                    break;
+                }
 
-                    switch (match.Groups[2].Value)
+                case "VP":
+                {
+                    var minVis = int.Parse(match.Groups[4].Value);
+                    var maxVis = int.Parse(match.Groups[6].Value);
+
+                    result.Add(match.Groups[3].Value == "M"
+                        ? $"variable from less than {minVis.ToGroupForm()} to greater than{maxVis.ToGroupForm()}"
+                        : $"{minVis.ToGroupForm()} variable to greater than {maxVis.ToGroupForm()}");
+                    break;
+                }
+
+                default:
+                {
+                    var vis = int.Parse(match.Groups[4].Value);
+
+                    switch (match.Groups[3].Value)
                     {
-                        case "L":
-                            rwyDesignator = "left";
-                            break;
-                        case "R":
-                            rwyDesignator = "right";
-                            break;
-                        case "C":
-                            rwyDesignator = "center";
-                            break;
-                    }
-
-                    if (match.Groups[5].Value == "V")
-                    {
-                        var minVis = int.Parse(match.Groups[4].Value);
-                        var maxVis = int.Parse(match.Groups[6].Value);
-
-                        result.Add(match.Groups[3].Value == "M"
-                            ? $"variable from less than {minVis.ToGroupForm()} to {maxVis.ToGroupForm()}"
-                            : $"variable between {minVis.ToGroupForm()} and {maxVis.ToGroupForm()}");
-                    }
-                    else if (match.Groups[5].Value == "VP")
-                    {
-                        var minVis = int.Parse(match.Groups[4].Value);
-                        var maxVis = int.Parse(match.Groups[6].Value);
-
-                        result.Add(match.Groups[3].Value == "M"
-                            ? $"variable from less than {minVis.ToGroupForm()} to greater than{maxVis.ToGroupForm()}"
-                            : $"{minVis.ToGroupForm()} variable to greater than {maxVis.ToGroupForm()}");
-                    }
-                    else
-                    {
-                        var vis = int.Parse(match.Groups[4].Value);
-
-                        if (match.Groups[3].Value == "M")
-                        {
+                        case "M":
                             result.Add($"less than {vis.ToGroupForm()}");
-                        }
-                        else if (match.Groups[3].Value == "P")
-                        {
+                            break;
+                        case "P":
                             result.Add($"more than {vis.ToGroupForm()}");
-                        }
-                        else
-                        {
+                            break;
+                        default:
                             result.Add(vis.ToGroupForm());
-                        }
-                    }
-
-                    var tendency = "";
-                    switch (match.Groups[8].Value)
-                    {
-                        case "N":
-                            tendency = "neutral";
-                            break;
-                        case "U":
-                            tendency = "going up";
-                            break;
-                        case "D":
-                            tendency = "going down";
                             break;
                     }
 
-                    result.Add(tendency);
-
-                    tts.Add($"Runway {rwyNumber.ToSerialFormat()} {rwyDesignator} R-V-R {string.Join(" ", result)}.");
+                    break;
                 }
             }
+
+            var tendency = match.Groups[8].Value switch
+            {
+                "N" => Station?.AtisFormat.RunwayVisualRange.NeutralTendency,
+                "U" => Station?.AtisFormat.RunwayVisualRange.GoingUpTendency,
+                "D" => Station?.AtisFormat.RunwayVisualRange.GoingDownTendency,
+                _ => ""
+            };
+
+            if (tendency != null)
+            {
+                result.Add(tendency);
+            }
+
+            tts.Add($"Runway {rwyNumber.ToSerialFormat()} {rwyDesignator} R-V-R {string.Join(" ", result)}.");
         }
 
         TextAtis = string.Join(" ", acars);

--- a/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
@@ -28,6 +28,11 @@ public class AtisFormat
     public Visibility Visibility { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the runway visual range component of the ATIS format.
+    /// </summary>
+    public RunwayVisualRange RunwayVisualRange { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the present weather component of the ATIS format.
     /// </summary>
     public PresentWeather PresentWeather { get; set; } = new();
@@ -83,6 +88,7 @@ public class AtisFormat
             ObservationTime = ObservationTime.Clone(),
             SurfaceWind = SurfaceWind.Clone(),
             Visibility = Visibility.Clone(),
+            RunwayVisualRange = RunwayVisualRange.Clone(),
             PresentWeather = PresentWeather.Clone(),
             RecentWeather = RecentWeather.Clone(),
             Clouds = Clouds.Clone(),

--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/RunwayVisualRange.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/RunwayVisualRange.cs
@@ -1,0 +1,36 @@
+// <copyright file="RunwayVisualRange.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Profiles.AtisFormat.Nodes;
+
+/// <summary>
+/// Represents the runway visual range component of the ATIS format.
+/// </summary>
+public class RunwayVisualRange : BaseFormat
+{
+    /// <summary>
+    /// Gets or sets the neutral tendency.
+    /// </summary>
+    public string? NeutralTendency { get; set; } = "Neutral";
+
+    /// <summary>
+    /// Gets or sets the going up tendency.
+    /// </summary>
+    public string? GoingUpTendency { get; set; } = "Going Up";
+
+    /// <summary>
+    /// Gets or sets the going down tendency.
+    /// </summary>
+    public string? GoingDownTendency { get; set; } = "Going Down";
+
+    /// <summary>
+    /// Creates a new instance of <see cref="RunwayVisualRange"/> that is a copy of the current instance.
+    /// </summary>
+    /// <returns>A new <see cref="RunwayVisualRange"/> instance that is a copy of this instance.</returns>
+    public RunwayVisualRange Clone()
+    {
+        return (RunwayVisualRange)MemberwiseClone();
+    }
+}

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -433,6 +433,27 @@
 					</TabItem>
 				</TabControl>
 			</StackPanel>
+            <!--Runway Visual Range-->
+			<StackPanel Spacing="10" Margin="10,10,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Runway Visual Range'}">
+				<TabControl Margin="-3">
+					<TabItem Header="Tendencies (Spoken)">
+                        <StackPanel Orientation="Vertical" Spacing="10">
+                            <Grid ColumnDefinitions="130,*">
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is N">Neutral (N):</TextBlock>
+                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyNeutralText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            </Grid>
+                            <Grid ColumnDefinitions="130,*">
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is U">Going Up (U):</TextBlock>
+                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingUpText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                            </Grid>
+                            <Grid ColumnDefinitions="130,*">
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is D">Going Down (D):</TextBlock>
+                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingDownText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            </Grid>
+                        </StackPanel>
+					</TabItem>
+				</TabControl>
+			</StackPanel>
 			<!--Weather-->
 			<StackPanel Spacing="10" Margin="10,10,0,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Weather'}">
 				<TabControl Margin="-3">

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -91,6 +91,9 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private string? _visibilityUnlimitedVisibilityText;
     private bool _visibilityIncludeVisibilitySuffix;
     private int _visibilityMetersCutoff;
+    private string? _rvrTendencyNeutralText;
+    private string? _rvrTendencyGoingUpText;
+    private string? _rvrTendencyGoingDownText;
     private bool _cloudsIdentifyCeilingLayer;
     private bool _cloudsConvertToMetric;
     private string? _undeterminedLayerAltitudeText;
@@ -856,6 +859,45 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the RVR neutral tendency text template.
+    /// </summary>
+    public string? RvrTendencyNeutralText
+    {
+        get => _rvrTendencyNeutralText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _rvrTendencyNeutralText, value);
+            _changeTracker.TrackChange(nameof(RvrTendencyNeutralText), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the RVR going up tendency text template.
+    /// </summary>
+    public string? RvrTendencyGoingUpText
+    {
+        get => _rvrTendencyGoingUpText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _rvrTendencyGoingUpText, value);
+            _changeTracker.TrackChange(nameof(RvrTendencyGoingUpText), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the RVR going down tendency text template.
+    /// </summary>
+    public string? RvrTendencyGoingDownText
+    {
+        get => _rvrTendencyGoingDownText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _rvrTendencyGoingDownText, value);
+            _changeTracker.TrackChange(nameof(RvrTendencyGoingDownText), value);
+        }
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to identify ceiling layer.
     /// </summary>
     public bool CloudsIdentifyCeilingLayer
@@ -1454,6 +1496,21 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisFormat.Visibility.MetersCutoff = VisibilityMetersCutoff;
         }
 
+        if (SelectedStation.AtisFormat.RunwayVisualRange.NeutralTendency != RvrTendencyNeutralText)
+        {
+            SelectedStation.AtisFormat.RunwayVisualRange.NeutralTendency = RvrTendencyNeutralText;
+        }
+
+        if (SelectedStation.AtisFormat.RunwayVisualRange.GoingUpTendency != RvrTendencyGoingUpText)
+        {
+            SelectedStation.AtisFormat.RunwayVisualRange.GoingUpTendency = RvrTendencyGoingUpText;
+        }
+
+        if (SelectedStation.AtisFormat.RunwayVisualRange.GoingDownTendency != RvrTendencyGoingDownText)
+        {
+            SelectedStation.AtisFormat.RunwayVisualRange.GoingDownTendency = RvrTendencyGoingDownText;
+        }
+
         if (PresentWeatherTypes != null && SelectedStation.AtisFormat.PresentWeather.PresentWeatherTypes !=
             PresentWeatherTypes.ToDictionary(
                 x => x.Key,
@@ -1596,40 +1653,28 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
 
         SelectedStation = station;
 
-        FormattingOptions = [];
-        if (station.IsFaaAtis)
+        var items = new List<string>
         {
-            FormattingOptions =
-            [
-                "Observation Time",
-                "Wind",
-                "Visibility",
-                "Weather",
-                "Clouds",
-                "Temperature",
-                "Dewpoint",
-                "Altimeter",
-                "NOTAMs",
-                "Closing Statement"
-            ];
-        }
-        else
+            "Observation Time",
+            "Wind",
+            "Visibility",
+            "Runway Visual Range",
+            "Weather",
+            "Clouds",
+            "Temperature",
+            "Dewpoint",
+            "Altimeter"
+        };
+
+        if (!station.IsFaaAtis)
         {
-            FormattingOptions =
-            [
-                "Observation Time",
-                "Wind",
-                "Visibility",
-                "Weather",
-                "Clouds",
-                "Temperature",
-                "Dewpoint",
-                "Altimeter",
-                "Transition Level",
-                "NOTAMs",
-                "Closing Statement"
-            ];
+            items.Add("Transition Level");
         }
+
+        items.Add("NOTAMs");
+        items.Add("Closing Statement");
+
+        FormattingOptions = [.. items];
 
         SpeakWindSpeedLeadingZero = station.AtisFormat.SurfaceWind.SpeakLeadingZero;
         MagneticVariationEnabled = station.AtisFormat.SurfaceWind.MagneticVariation.Enabled;
@@ -1678,6 +1723,9 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         VisibilityUnlimitedVisibilityText = station.AtisFormat.Visibility.UnlimitedVisibilityText;
         VisibilityIncludeVisibilitySuffix = station.AtisFormat.Visibility.IncludeVisibilitySuffix;
         VisibilityMetersCutoff = station.AtisFormat.Visibility.MetersCutoff;
+        RvrTendencyNeutralText = station.AtisFormat.RunwayVisualRange.NeutralTendency;
+        RvrTendencyGoingUpText = station.AtisFormat.RunwayVisualRange.GoingUpTendency;
+        RvrTendencyGoingDownText = station.AtisFormat.RunwayVisualRange.GoingDownTendency;
         CloudsIdentifyCeilingLayer = station.AtisFormat.Clouds.IdentifyCeilingLayer;
         CloudsConvertToMetric = station.AtisFormat.Clouds.ConvertToMetric;
         CloudHeightAltitudeInHundreds = station.AtisFormat.Clouds.IsAltitudeInHundreds;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new section in the configuration UI for customizing spoken text for runway visual range (RVR) tendencies: Neutral, Going Up, and Going Down.
  - Users can now configure the spoken descriptions for RVR tendencies directly within the app settings.
- **Enhancements**
  - "Runway Visual Range" is now available as a formatting option for all stations.
  - Improved clarity and organization of formatting options in the configuration view.
  - Introduced runway visual range (RVR) support in ATIS format, including customizable tendency descriptions.
  - Enhanced parsing and presentation of runway visual range data for clearer spoken output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->