### PR TITLE
[VATIS-143] TREND and WS Formatting

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/TrendNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TrendNode.cs
@@ -78,16 +78,16 @@ public class TrendNode : BaseNode<TrendForecast>
         switch (forecast.ChangeIndicator)
         {
             case TrendForecastType.Becoming:
-                voiceAtis.Add("BECOMING");
-                textAtis.Add("BECMG");
+                voiceAtis.Add(Station.AtisFormat.Trend.BecomingVoice ?? "BECOMING");
+                textAtis.Add(Station.AtisFormat.Trend.BecomingText ?? "BECMG");
                 break;
             case TrendForecastType.Temporary:
-                voiceAtis.Add("TEMPORARY");
-                textAtis.Add("TEMPO");
+                voiceAtis.Add(Station.AtisFormat.Trend.TemporaryVoice ?? "TEMPORARY");
+                textAtis.Add(Station.AtisFormat.Trend.TemporaryText ??"TEMPO");
                 break;
             case TrendForecastType.NoSignificantChanges:
-                voiceAtis.Add("NO SIGNIFICANT CHANGES");
-                textAtis.Add("NOSIG");
+                voiceAtis.Add(Station.AtisFormat.Trend.NosigVoice ??"NO SIGNIFICANT CHANGES");
+                textAtis.Add(Station.AtisFormat.Trend.NosigText ??"NOSIG");
                 break;
         }
 

--- a/vATIS.Desktop/Atis/Nodes/TrendNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TrendNode.cs
@@ -19,7 +19,7 @@ public class TrendNode : BaseNode<TrendForecast>
     /// <inheritdoc/>
     public override void Parse(DecodedMetar metar)
     {
-        if (Station == null || metar.TrendForecast == null)
+        if (Station == null)
             return;
 
         var voiceAtis = new List<string>();
@@ -67,8 +67,23 @@ public class TrendNode : BaseNode<TrendForecast>
     private void ProcessTrendForecast(TrendForecast? forecast, DecodedMetar decodedTrend, List<string> voiceAtis,
         List<string> textAtis, bool isFuture = false)
     {
-        if (forecast == null || Station == null)
+        if (Station == null)
             return;
+
+        if (forecast == null)
+        {
+            if (!string.IsNullOrEmpty(Station.AtisFormat.Trend.NotAvailableVoice))
+            {
+                voiceAtis.Add(Station.AtisFormat.Trend.NotAvailableVoice);
+            }
+
+            if (!string.IsNullOrEmpty(Station.AtisFormat.Trend.NotAvailableText))
+            {
+                textAtis.Add(Station.AtisFormat.Trend.NotAvailableText);
+            }
+
+            return;
+        }
 
         if (!isFuture)
         {

--- a/vATIS.Desktop/Atis/Nodes/TrendNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/TrendNode.cs
@@ -83,11 +83,11 @@ public class TrendNode : BaseNode<TrendForecast>
                 break;
             case TrendForecastType.Temporary:
                 voiceAtis.Add(Station.AtisFormat.Trend.TemporaryVoice ?? "TEMPORARY");
-                textAtis.Add(Station.AtisFormat.Trend.TemporaryText ??"TEMPO");
+                textAtis.Add(Station.AtisFormat.Trend.TemporaryText ?? "TEMPO");
                 break;
             case TrendForecastType.NoSignificantChanges:
-                voiceAtis.Add(Station.AtisFormat.Trend.NosigVoice ??"NO SIGNIFICANT CHANGES");
-                textAtis.Add(Station.AtisFormat.Trend.NosigText ??"NOSIG");
+                voiceAtis.Add(Station.AtisFormat.Trend.NosigVoice ?? "NO SIGNIFICANT CHANGES");
+                textAtis.Add(Station.AtisFormat.Trend.NosigText ?? "NOSIG");
                 break;
         }
 

--- a/vATIS.Desktop/Atis/Nodes/WindShearNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/WindShearNode.cs
@@ -20,8 +20,8 @@ public class WindShearNode : BaseNode<string>
     {
         if (metar.WindshearAllRunways.HasValue && metar.WindshearAllRunways.Value)
         {
-            TextAtis = "WS ALL RWY";
-            VoiceAtis = "WIND SHEAR ALL RUNWAYS";
+            TextAtis = Station?.AtisFormat.WindShear.AllRunwayText ?? Defaults.AllRunwayText;
+            VoiceAtis = Station?.AtisFormat.WindShear.AllRunwayVoice ?? Defaults.AllRunwayVoice;
         }
         else if (metar.WindshearRunways != null)
         {
@@ -30,7 +30,10 @@ public class WindShearNode : BaseNode<string>
 
             foreach (var runway in metar.WindshearRunways)
             {
-                textResult.Add($"WS R{runway}");
+                var text = Regex.Replace(Station?.AtisFormat?.WindShear.RunwayText ?? Defaults.RunwayTextFormat,
+                    "{Runway}", runway, RegexOptions.IgnoreCase);
+
+                textResult.Add(text);
 
                 var match = Regex.Match(runway, @"(\d{2})([LCR]?)");
                 if (match.Success)
@@ -45,8 +48,10 @@ public class WindShearNode : BaseNode<string>
                             _ => ""
                         };
 
-                        voiceResult.Add(
-                            $"WIND SHEAR RUNWAY {runwayNumber.ToSerialFormat(leadingZero: true)}{runwaySide}");
+                        var voice = Regex.Replace(
+                            Station?.AtisFormat?.WindShear.RunwayVoice ?? Defaults.RunwayVoiceFormat, "{Runway}",
+                            $"{runwayNumber.ToSerialFormat(leadingZero: true)}{runwaySide}", RegexOptions.IgnoreCase);
+                        voiceResult.Add(voice);
                     }
                 }
             }
@@ -63,4 +68,12 @@ public class WindShearNode : BaseNode<string>
     /// <inheritdoc />
     public override string ParseTextVariables(string node, string? format) =>
         throw new System.NotImplementedException();
+
+    private static class Defaults
+    {
+        public const string AllRunwayText = "WS ALL RWY";
+        public const string AllRunwayVoice = "WIND SHEAR ALL RUNWAYS";
+        public const string RunwayTextFormat = "WS R{Runway}";
+        public const string RunwayVoiceFormat = "WIND SHEAR RUNWAY {Runway}";
+    }
 }

--- a/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
@@ -63,6 +63,11 @@ public class AtisFormat
     public Altimeter Altimeter { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the formatting for the TREND component.
+    /// </summary>
+    public Trend Trend { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the transition level component of the ATIS format.
     /// </summary>
     public TransitionLevel TransitionLevel { get; set; } = new();

--- a/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/AtisFormat.cs
@@ -68,6 +68,11 @@ public class AtisFormat
     public Trend Trend { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the formatting for the WS component.
+    /// </summary>
+    public WindShear WindShear { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the transition level component of the ATIS format.
     /// </summary>
     public TransitionLevel TransitionLevel { get; set; } = new();
@@ -100,6 +105,8 @@ public class AtisFormat
             Temperature = Temperature.Clone(),
             Dewpoint = Dewpoint.Clone(),
             Altimeter = Altimeter.Clone(),
+            Trend = Trend.Clone(),
+            WindShear = WindShear.Clone(),
             TransitionLevel = TransitionLevel.Clone(),
             Notams = Notams.Clone(),
             ClosingStatement = ClosingStatement.Clone(),

--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/Trend.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/Trend.cs
@@ -1,0 +1,51 @@
+// <copyright file="Trend.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Profiles.AtisFormat.Nodes;
+
+/// <summary>
+/// Represents the TREND component of the ATIS format.
+/// </summary>
+public class Trend : BaseFormat
+{
+    /// <summary>
+    /// Gets or sets the NOSIG text value.
+    /// </summary>
+    public string? NosigText { get; set; } = "NOSIG";
+
+    /// <summary>
+    /// Gets or sets the NOSIG voice value.
+    /// </summary>
+    public string? NosigVoice { get; set; } = "No Significant Changes";
+
+    /// <summary>
+    /// Gets or sets the BECMG text value.
+    /// </summary>
+    public string? BecomingText { get; set; } = "BECMG";
+
+    /// <summary>
+    /// Gets or sets the BECMG voice value.
+    /// </summary>
+    public string? BecomingVoice { get; set; } = "Becoming";
+
+    /// <summary>
+    /// Gets or sets the TEMPO text value.
+    /// </summary>
+    public string? TemporaryText { get; set; } = "TEMPO";
+
+    /// <summary>
+    /// Gets or sets the TEMPO voice value.
+    /// </summary>
+    public string? TemporaryVoice { get; set; } = "Temporary";
+
+    /// <summary>
+    /// Creates a new instance of <see cref="Trend"/> that is a copy of the current instance.
+    /// </summary>
+    /// <returns>A new <see cref="Trend"/> instance that is a copy of this instance.</returns>
+    public Trend Clone()
+    {
+        return (Trend)MemberwiseClone();
+    }
+}

--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/Trend.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/Trend.cs
@@ -41,6 +41,16 @@ public class Trend : BaseFormat
     public string? TemporaryVoice { get; set; } = "Temporary";
 
     /// <summary>
+    /// Gets or sets the text value for when the TREND is not available.
+    /// </summary>
+    public string? NotAvailableText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the voice value for when the TREND is not available.
+    /// </summary>
+    public string? NotAvailableVoice { get; set; }
+
+    /// <summary>
     /// Creates a new instance of <see cref="Trend"/> that is a copy of the current instance.
     /// </summary>
     /// <returns>A new <see cref="Trend"/> instance that is a copy of this instance.</returns>

--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/WindShear.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/WindShear.cs
@@ -1,0 +1,41 @@
+// <copyright file="WindShear.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Profiles.AtisFormat.Nodes;
+
+/// <summary>
+/// Represents the WS component of the ATIS format.
+/// </summary>
+public class WindShear : BaseFormat
+{
+    /// <summary>
+    /// Gets or sets the text for individual runway wind shear.
+    /// </summary>
+    public string? RunwayText { get; set; } = "WS R{Runway}";
+
+    /// <summary>
+    /// Gets or sets the voice for individual runway wind shear.
+    /// </summary>
+    public string? RunwayVoice { get; set; } = "Wind Shear Runway {Runway}";
+
+    /// <summary>
+    /// Gets or sets the text for all runway wind shears.
+    /// </summary>
+    public string? AllRunwayText { get; set; } = "WS ALL RWY";
+
+    /// <summary>
+    /// Gets or sets the voice for all runway wind shears.
+    /// </summary>
+    public string? AllRunwayVoice { get; set; } = "Wind Shear All Runways";
+
+    /// <summary>
+    /// Creates a new instance of <see cref="WindShear"/> that is a copy of the current instance.
+    /// </summary>
+    /// <returns>A new <see cref="WindShear"/> instance that is a copy of this instance.</returns>
+    public WindShear Clone()
+    {
+        return (WindShear)MemberwiseClone();
+    }
+}

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -789,18 +789,23 @@
                         </Grid>
                         <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
                             <TextBlock Grid.Column="0" VerticalAlignment="Center">NOSIG</TextBlock>
-                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding NosigTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
-                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding NosigVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="1" Text="{Binding NosigTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Text="{Binding NosigVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
                         </Grid>
                         <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
                             <TextBlock Grid.Column="0" VerticalAlignment="Center">BECMG</TextBlock>
-                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding BecomingTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
-                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding BecomingVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="1" Text="{Binding BecomingTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Text="{Binding BecomingVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
                         </Grid>
                         <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
                             <TextBlock Grid.Column="0" VerticalAlignment="Center">TEMPO</TextBlock>
-                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding TemporaryTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
-                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding TemporaryVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="1" Text="{Binding TemporaryTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Text="{Binding TemporaryVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                        <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="Text to print and/or say when the TREND is not available in the METAR">Not Available</TextBlock>
+                            <TextBox Grid.Column="1" Text="{Binding TrendNotAvailableTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Text="{Binding TrendNotAvailableVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
                         </Grid>
                     </StackPanel>
                 </groupBox:GroupBoxControl>

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -753,7 +753,31 @@
 			</StackPanel>
             <!--Wind Shear-->
 			<StackPanel Spacing="10" Margin="10,10,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Wind Shear'}">
-
+                <StackPanel Orientation="Vertical" Spacing="10">
+                    <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                        <TextBlock Grid.Column="1">Text</TextBlock>
+                        <TextBlock Grid.Column="2">Voice</TextBlock>
+                    </Grid>
+                    <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center">Runway Specific</TextBlock>
+                        <controls:TemplateVariableTextBox Grid.Column="1" Watermark="Text" Text="{Binding RunwayWindShearText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                        <controls:TemplateVariableTextBox Grid.Column="2" Watermark="Voice" Text="{Binding RunwayWindShearVoice, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                    </Grid>
+                    <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center">All Runways</TextBlock>
+                        <controls:TemplateVariableTextBox Grid.Column="1" Watermark="Text" Text="{Binding AllRunwayWindShearText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                        <controls:TemplateVariableTextBox Grid.Column="2" Watermark="Voice" Text="{Binding AllRunwayWindShearVoice, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                    </Grid>
+                    <WrapPanel>
+                        <Button
+                            Theme="{StaticResource DarkVariable}" Margin="0,8,0,0"
+                            ToolTip.Tip="This will be replaced by the runway identifier (e.g. 04R)."
+                            Command="{Binding TemplateVariableClicked, DataType=vm:FormattingViewModel}"
+                            CommandParameter="{Binding $self.Content}">
+                            {Runway}
+                        </Button>
+                    </WrapPanel>
+                </StackPanel>
             </StackPanel>
             <!--Trend Forecast-->
             <StackPanel Spacing="10" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Trend Forecast'}">

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -441,25 +441,23 @@
 				</TabControl>
 			</StackPanel>
             <!--Runway Visual Range-->
-			<StackPanel Spacing="10" Margin="10,10,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Runway Visual Range'}">
-				<TabControl Margin="-3">
-					<TabItem Header="Tendencies (Spoken)">
-                        <StackPanel Orientation="Vertical" Spacing="10">
-                            <Grid ColumnDefinitions="130,*">
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is N">Neutral (N):</TextBlock>
-                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyNeutralText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
-                            </Grid>
-                            <Grid ColumnDefinitions="130,*">
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is U">Going Up (U):</TextBlock>
-                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingUpText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
-                            </Grid>
-                            <Grid ColumnDefinitions="130,*">
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is D">Going Down (D):</TextBlock>
-                                <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingDownText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
-                            </Grid>
-                        </StackPanel>
-					</TabItem>
-				</TabControl>
+			<StackPanel Spacing="10" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Runway Visual Range'}">
+                <groupBox:GroupBoxControl Header="Tendencies (Spoken)" Theme="{StaticResource GroupBoxClassic}">
+                    <StackPanel Orientation="Vertical" Spacing="10">
+                        <Grid ColumnDefinitions="130,*">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is N">Neutral (N):</TextBlock>
+                            <TextBox Grid.Column="1" Text="{Binding RvrTendencyNeutralText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                        <Grid ColumnDefinitions="130,*">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is U">Going Up (U):</TextBlock>
+                            <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingUpText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="130,*">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" ToolTip.Tip="The spoken text if the tendency is D">Going Down (D):</TextBlock>
+                            <TextBox Grid.Column="1" Text="{Binding RvrTendencyGoingDownText, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                    </StackPanel>
+				</groupBox:GroupBoxControl>
 			</StackPanel>
 			<!--Weather-->
 			<StackPanel Spacing="10" Margin="10,10,0,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Weather'}">
@@ -753,6 +751,36 @@
 					</StackPanel>
 				</groupBox:GroupBoxControl>
 			</StackPanel>
+            <!--Wind Shear-->
+			<StackPanel Spacing="10" Margin="10,10,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Wind Shear'}">
+
+            </StackPanel>
+            <!--Trend Forecast-->
+            <StackPanel Spacing="10" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Trend Forecast'}">
+                <groupBox:GroupBoxControl Header="Change Indicator" Theme="{StaticResource GroupBoxClassic}">
+                    <StackPanel Orientation="Vertical" Spacing="10">
+                        <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                            <TextBlock Grid.Column="1">Text</TextBlock>
+                            <TextBlock Grid.Column="2">Voice</TextBlock>
+                        </Grid>
+                        <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center">NOSIG</TextBlock>
+                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding NosigTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding NosigVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                        <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center">BECMG</TextBlock>
+                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding BecomingTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding BecomingVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                        <Grid ColumnDefinitions="100,*,*" ColumnSpacing="10">
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center">TEMPO</TextBlock>
+                            <TextBox Grid.Column="1" Watermark="Text" Text="{Binding TemporaryTextValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                            <TextBox Grid.Column="2" Watermark="Voice" Text="{Binding TemporaryVoiceValue, DataType=vm:FormattingViewModel}" Theme="{StaticResource DarkTextBox}"></TextBox>
+                        </Grid>
+                    </StackPanel>
+                </groupBox:GroupBoxControl>
+            </StackPanel>
 			<!--Transition Level-->
 			<StackPanel Spacing="10" Margin="10,10,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Transition Level'}">
 				<TabControl Margin="-3">

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -112,6 +112,8 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private string? _becomingVoiceValue;
     private string? _temporaryTextValue;
     private string? _temporaryVoiceValue;
+    private string? _trendNotAvailableText;
+    private string? _trendNotAvailableVoice;
     private string? _runwayWindShearText;
     private string? _runwayWindShearVoice;
     private string? _allRunwayWindShearText;
@@ -1155,6 +1157,32 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the text value when TREND is not available.
+    /// </summary>
+    public string? TrendNotAvailableTextValue
+    {
+        get => _trendNotAvailableText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _trendNotAvailableText, value);
+            _changeTracker.TrackChange(nameof(TrendNotAvailableTextValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the voice value when TREND is not available.
+    /// </summary>
+    public string? TrendNotAvailableVoiceValue
+    {
+        get => _trendNotAvailableVoice;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _trendNotAvailableVoice, value);
+            _changeTracker.TrackChange(nameof(TrendNotAvailableVoiceValue), value);
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the text value for individual runway wind shear.
     /// </summary>
     public string? RunwayWindShearText
@@ -1770,6 +1798,16 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisFormat.Trend.TemporaryVoice = TemporaryVoiceValue;
         }
 
+        if (SelectedStation.AtisFormat.Trend.NotAvailableText != TrendNotAvailableTextValue)
+        {
+            SelectedStation.AtisFormat.Trend.NotAvailableText = TrendNotAvailableTextValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.NotAvailableVoice != TrendNotAvailableVoiceValue)
+        {
+            SelectedStation.AtisFormat.Trend.NotAvailableVoice = TrendNotAvailableVoiceValue;
+        }
+
         if (SelectedStation.AtisFormat.WindShear.RunwayText != RunwayWindShearText)
         {
             SelectedStation.AtisFormat.WindShear.RunwayText = RunwayWindShearText;
@@ -1936,6 +1974,8 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         BecomingVoiceValue = station.AtisFormat.Trend.BecomingVoice;
         TemporaryTextValue = station.AtisFormat.Trend.TemporaryText;
         TemporaryVoiceValue = station.AtisFormat.Trend.TemporaryVoice;
+        TrendNotAvailableTextValue = station.AtisFormat.Trend.NotAvailableText;
+        TrendNotAvailableVoiceValue = station.AtisFormat.Trend.NotAvailableVoice;
         RunwayWindShearText = station.AtisFormat.WindShear.RunwayText;
         RunwayWindShearVoice = station.AtisFormat.WindShear.RunwayVoice;
         AllRunwayWindShearText = station.AtisFormat.WindShear.AllRunwayText;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -112,6 +112,10 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private string? _becomingVoiceValue;
     private string? _temporaryTextValue;
     private string? _temporaryVoiceValue;
+    private string? _runwayWindShearText;
+    private string? _runwayWindShearVoice;
+    private string? _allRunwayWindShearText;
+    private string? _allRunwayWindShearVoice;
     private bool _closingStatementAutoIncludeClosingStatement;
     private ObservableCollection<TransitionLevelMeta>? _transitionLevelMetas;
     private string? _transitionLevelTextTemplate;
@@ -1151,6 +1155,58 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the text value for individual runway wind shear.
+    /// </summary>
+    public string? RunwayWindShearText
+    {
+        get => _runwayWindShearText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _runwayWindShearText, value);
+            _changeTracker.TrackChange(nameof(RunwayWindShearText), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the voice value for individual runway wind shear.
+    /// </summary>
+    public string? RunwayWindShearVoice
+    {
+        get => _runwayWindShearVoice;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _runwayWindShearVoice, value);
+            _changeTracker.TrackChange(nameof(RunwayWindShearVoice), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the text value for all runway wind shear.
+    /// </summary>
+    public string? AllRunwayWindShearText
+    {
+        get => _allRunwayWindShearText;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _allRunwayWindShearText, value);
+            _changeTracker.TrackChange(nameof(AllRunwayWindShearText), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the voice value for all runway wind shear.
+    /// </summary>
+    public string? AllRunwayWindShearVoice
+    {
+        get => _allRunwayWindShearVoice;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _allRunwayWindShearVoice, value);
+            _changeTracker.TrackChange(nameof(AllRunwayWindShearVoice), value);
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the transition levels.
     /// </summary>
     public ObservableCollection<TransitionLevelMeta>? TransitionLevels
@@ -1714,6 +1770,26 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisFormat.Trend.TemporaryVoice = TemporaryVoiceValue;
         }
 
+        if (SelectedStation.AtisFormat.WindShear.RunwayText != RunwayWindShearText)
+        {
+            SelectedStation.AtisFormat.WindShear.RunwayText = RunwayWindShearText;
+        }
+
+        if (SelectedStation.AtisFormat.WindShear.RunwayVoice != RunwayWindShearVoice)
+        {
+            SelectedStation.AtisFormat.WindShear.RunwayVoice = RunwayWindShearVoice;
+        }
+
+        if (SelectedStation.AtisFormat.WindShear.AllRunwayText != AllRunwayWindShearText)
+        {
+            SelectedStation.AtisFormat.WindShear.AllRunwayText = AllRunwayWindShearText;
+        }
+
+        if (SelectedStation.AtisFormat.WindShear.AllRunwayVoice != AllRunwayWindShearVoice)
+        {
+            SelectedStation.AtisFormat.WindShear.AllRunwayVoice = AllRunwayWindShearVoice;
+        }
+
         if (SelectedStation.AtisFormat.ClosingStatement.AutoIncludeClosingStatement !=
             ClosingStatementAutoIncludeClosingStatement)
         {
@@ -1860,6 +1936,10 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         BecomingVoiceValue = station.AtisFormat.Trend.BecomingVoice;
         TemporaryTextValue = station.AtisFormat.Trend.TemporaryText;
         TemporaryVoiceValue = station.AtisFormat.Trend.TemporaryVoice;
+        RunwayWindShearText = station.AtisFormat.WindShear.RunwayText;
+        RunwayWindShearVoice = station.AtisFormat.WindShear.RunwayVoice;
+        AllRunwayWindShearText = station.AtisFormat.WindShear.AllRunwayText;
+        AllRunwayWindShearVoice = station.AtisFormat.WindShear.AllRunwayVoice;
         NotamsTextTemplate = station.AtisFormat.Notams.Template.Text;
         NotamsVoiceTemplate = station.AtisFormat.Notams.Template.Voice;
         ClosingStatementAutoIncludeClosingStatement =

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -106,6 +106,12 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private bool _dewpointUsePlusPrefix;
     private bool _dewpointSpeakLeadingZero;
     private bool _altimeterSpeakDecimal;
+    private string? _nosigTextValue;
+    private string? _nosigVoiceValue;
+    private string? _becomingTextValue;
+    private string? _becomingVoiceValue;
+    private string? _temporaryTextValue;
+    private string? _temporaryVoiceValue;
     private bool _closingStatementAutoIncludeClosingStatement;
     private ObservableCollection<TransitionLevelMeta>? _transitionLevelMetas;
     private string? _transitionLevelTextTemplate;
@@ -1067,6 +1073,84 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the NOSIG text value.
+    /// </summary>
+    public string? NosigTextValue
+    {
+        get => _nosigTextValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _nosigTextValue, value);
+            _changeTracker.TrackChange(nameof(NosigTextValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the NOSIG voice value.
+    /// </summary>
+    public string? NosigVoiceValue
+    {
+        get => _nosigVoiceValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _nosigVoiceValue, value);
+            _changeTracker.TrackChange(nameof(NosigVoiceValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the BECMG text value.
+    /// </summary>
+    public string? BecomingTextValue
+    {
+        get => _becomingTextValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _becomingTextValue, value);
+            _changeTracker.TrackChange(nameof(BecomingTextValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the BECMG voice value.
+    /// </summary>
+    public string? BecomingVoiceValue
+    {
+        get => _becomingVoiceValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _becomingVoiceValue, value);
+            _changeTracker.TrackChange(nameof(BecomingVoiceValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the TEMPO text value.
+    /// </summary>
+    public string? TemporaryTextValue
+    {
+        get => _temporaryTextValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _temporaryTextValue, value);
+            _changeTracker.TrackChange(nameof(TemporaryTextValue), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the TEMPO voice value.
+    /// </summary>
+    public string? TemporaryVoiceValue
+    {
+        get => _temporaryVoiceValue;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _temporaryVoiceValue, value);
+            _changeTracker.TrackChange(nameof(TemporaryVoiceValue), value);
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the transition levels.
     /// </summary>
     public ObservableCollection<TransitionLevelMeta>? TransitionLevels
@@ -1600,6 +1684,36 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisFormat.Altimeter.PronounceDecimal = AltimeterSpeakDecimal;
         }
 
+        if (SelectedStation.AtisFormat.Trend.NosigText != NosigTextValue)
+        {
+            SelectedStation.AtisFormat.Trend.NosigText = NosigTextValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.NosigVoice != NosigVoiceValue)
+        {
+            SelectedStation.AtisFormat.Trend.NosigVoice = NosigVoiceValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.BecomingText != BecomingTextValue)
+        {
+            SelectedStation.AtisFormat.Trend.BecomingText = BecomingTextValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.BecomingVoice != BecomingVoiceValue)
+        {
+            SelectedStation.AtisFormat.Trend.BecomingVoice = BecomingVoiceValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.TemporaryText != TemporaryTextValue)
+        {
+            SelectedStation.AtisFormat.Trend.TemporaryText = TemporaryTextValue;
+        }
+
+        if (SelectedStation.AtisFormat.Trend.TemporaryVoice != TemporaryVoiceValue)
+        {
+            SelectedStation.AtisFormat.Trend.TemporaryVoice = TemporaryVoiceValue;
+        }
+
         if (SelectedStation.AtisFormat.ClosingStatement.AutoIncludeClosingStatement !=
             ClosingStatementAutoIncludeClosingStatement)
         {
@@ -1668,6 +1782,8 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
 
         if (!station.IsFaaAtis)
         {
+            items.Add("Wind Shear");
+            items.Add("Trend Forecast");
             items.Add("Transition Level");
         }
 
@@ -1738,6 +1854,12 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         DewpointUsePlusPrefix = station.AtisFormat.Dewpoint.UsePlusPrefix;
         DewpointSpeakLeadingZero = station.AtisFormat.Dewpoint.SpeakLeadingZero;
         AltimeterSpeakDecimal = station.AtisFormat.Altimeter.PronounceDecimal;
+        NosigTextValue = station.AtisFormat.Trend.NosigText;
+        NosigVoiceValue = station.AtisFormat.Trend.NosigVoice;
+        BecomingTextValue = station.AtisFormat.Trend.BecomingText;
+        BecomingVoiceValue = station.AtisFormat.Trend.BecomingVoice;
+        TemporaryTextValue = station.AtisFormat.Trend.TemporaryText;
+        TemporaryVoiceValue = station.AtisFormat.Trend.TemporaryVoice;
         NotamsTextTemplate = station.AtisFormat.Notams.Template.Text;
         NotamsVoiceTemplate = station.AtisFormat.Notams.Template.Voice;
         ClosingStatementAutoIncludeClosingStatement =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable text and voice labels for trend forecast change indicators (NOSIG, BECMG, TEMPO) in ATIS messages.
  - Introduced a new "Trend Forecast" configuration section in the formatting settings, allowing users to edit these labels.
  - Added a "Wind Shear" formatting option with editable text and voice templates for individual and all-runway wind shear reports.
  - Added a "Wind Shear" section to the configuration interface for managing wind shear message formatting.

- **Improvements**
  - The ATIS output now uses user-configured trend indicator and wind shear labels, with sensible defaults if not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->