### PR TITLE
Publish text ATIS string to hub

### DIFF
--- a/DevServer/Hub/Dto/AtisHubDto.cs
+++ b/DevServer/Hub/Dto/AtisHubDto.cs
@@ -56,4 +56,9 @@ public class AtisHubDto
     /// Gets or sets the NOTAMs.
     /// </summary>
     public string? Notams { get; set; }
+
+    /// <summary>
+    /// Gets or sets the complete text ATIS string.
+    /// </summary>
+    public string? TextAtis { get; set; }
 }

--- a/vATIS.Desktop/Networking/AtisHub/Dto/AtisHubDto.cs
+++ b/vATIS.Desktop/Networking/AtisHub/Dto/AtisHubDto.cs
@@ -18,13 +18,14 @@ public class AtisHubDto
     /// <param name="stationId">The identifier of the station.</param>
     /// <param name="atisType">The type of ATIS.</param>
     /// <param name="atisLetter">The letter associated with the ATIS.</param>
-    /// <param name="metar">The METAR (Meteorological Aerodrome Report) information.</param>
+    /// <param name="metar">The raw METAR string.</param>
     /// <param name="wind">The wind information.</param>
     /// <param name="altimeter">The altimeter setting.</param>
     /// <param name="airportConditions">The airport conditions.</param>
     /// <param name="notams">The NOTAMs.</param>
+    /// <param name="textAtis">The complete text ATIS string.</param>
     public AtisHubDto(string stationId, AtisType atisType, char atisLetter, string? metar = null, string? wind = null,
-        string? altimeter = null, string? airportConditions = null, string? notams = null)
+        string? altimeter = null, string? airportConditions = null, string? notams = null, string? textAtis = null)
     {
         StationId = stationId;
         AtisType = atisType;
@@ -34,6 +35,7 @@ public class AtisHubDto
         Altimeter = altimeter;
         AirportConditions = airportConditions;
         Notams = notams;
+        TextAtis = textAtis;
     }
 
     /// <summary>
@@ -80,4 +82,9 @@ public class AtisHubDto
     /// Gets or sets the NOTAMs.
     /// </summary>
     public string? Notams { get; set; }
+
+    /// <summary>
+    /// Gets or sets the complete text ATIS string.
+    /// </summary>
+    public string? TextAtis { get; set; }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -284,6 +284,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 Altimeter = sync.Dto.Altimeter;
                 Metar = sync.Dto.Metar;
                 ObservationTime = _decodedMetar?.Time.Replace(":", "");
+                AtisStation.TextAtis = sync.Dto.TextAtis;
                 NetworkConnectionStatus = sync.Dto.IsOnline
                     ? NetworkConnectionStatus.Observer
                     : NetworkConnectionStatus.Disconnected;
@@ -335,6 +336,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     ObservationTime = null;
                     NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;
                     IsNewAtis = false;
+                    AtisStation.TextAtis = null;
 
                     // Clear Airport Conditions and NOTAMs
                     if (AirportConditionsTextDocument != null)
@@ -1528,7 +1530,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             var notams = await Dispatcher.UIThread.InvokeAsync(() => NotamsTextDocument?.Text);
 
             await _atisHubConnection.PublishAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
-                AtisLetter, Metar?.Trim(), Wind?.Trim(), Altimeter?.Trim(), airportConditions?.Trim(), notams?.Trim()));
+                AtisLetter, Metar?.Trim(), Wind?.Trim(), Altimeter?.Trim(), airportConditions?.Trim(), notams?.Trim(),
+                AtisStation.TextAtis?.Trim()));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying and synchronizing the complete text ATIS string within the application.
  - The text ATIS content is now included when publishing updates and is kept in sync with the hub.
- **Enhancements**
  - Improved handling of ATIS expiration by clearing the text ATIS content when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->