### PR TITLE
Shared ATIS update notification sound

### DIFF
--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -32,7 +32,10 @@ public class AppConfig : IAppConfig
     public NetworkRating NetworkRating { get; set; } = NetworkRating.Obs;
 
     /// <inheritdoc />
-    public bool SuppressNotificationSound { get; set; }
+    public bool MuteOwnAtisUpdateSound { get; set; }
+
+    /// <inheritdoc />
+    public bool MuteSharedAtisUpdateSound { get; set; }
 
     /// <inheritdoc />
     public bool AlwaysOnTop { get; set; }
@@ -97,7 +100,8 @@ public class AppConfig : IAppConfig
             UserId = config.UserId;
             Password = config.Password;
             NetworkRating = config.NetworkRating;
-            SuppressNotificationSound = config.SuppressNotificationSound;
+            MuteOwnAtisUpdateSound = config.MuteOwnAtisUpdateSound;
+            MuteSharedAtisUpdateSound = config.MuteSharedAtisUpdateSound;
             AlwaysOnTop = config.AlwaysOnTop;
             CompactWindowAlwaysOnTop = config.CompactWindowAlwaysOnTop;
             CompactWindowShowMetarDetails = config.CompactWindowShowMetarDetails;

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -38,9 +38,14 @@ public interface IAppConfig
     NetworkRating NetworkRating { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether notification sounds are suppressed.
+    /// Gets or sets a value indicating whether to suppress update sound for own ATIS updates.
     /// </summary>
-    bool SuppressNotificationSound { get; set; }
+    bool MuteOwnAtisUpdateSound { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to suppress update sound for shared ATIS updates.
+    /// </summary>
+    bool MuteSharedAtisUpdateSound { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the application's main window should always remain on top of other windows.

--- a/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
@@ -44,7 +44,8 @@
 					<ComboBox Classes="Dark" HorizontalAlignment="Stretch" ItemsSource="{Binding NetworkRatings, DataType=vm:SettingsDialogViewModel}" DisplayMemberBinding="{Binding Display, DataType=common:ComboBoxItemMeta}" SelectedValueBinding="{Binding Value, DataType=common:ComboBoxItemMeta}" SelectedValue="{Binding SelectedNetworkRating, DataType=vm:SettingsDialogViewModel}"/>
 				</StackPanel>
 				<StackPanel>
-					<CheckBox Theme="{StaticResource CheckBox}" Content="Suppress ATIS update notification sound" IsChecked="{Binding SuppressNotificationSound, DataType=vm:SettingsDialogViewModel}" />
+					<CheckBox Theme="{StaticResource CheckBox}" Content="Mute own ATIS update sound" IsChecked="{Binding MuteOwnAtisUpdateSound, DataType=vm:SettingsDialogViewModel}" />
+                    <CheckBox Theme="{StaticResource CheckBox}" Content="Mute shared ATIS update sound" IsChecked="{Binding MuteSharedAtisUpdateSound, DataType=vm:SettingsDialogViewModel}" />
 					<CheckBox Theme="{StaticResource CheckBox}" Content="Automatically fetch ATIS letter" ToolTip.Tip="Fetch the real-world ATIS letter for supported stations automatically after connecting to the network." IsChecked="{Binding AutoFetchAtisLetter, DataType=vm:SettingsDialogViewModel}" />
 				</StackPanel>
 				<Grid ColumnDefinitions="1*,5,1*">

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -277,6 +277,10 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                      !string.Equals(sync.Dto.Metar, Metar, StringComparison.OrdinalIgnoreCase)))
                 {
                     IsNewAtis = true;
+                    if (!_appConfig.MuteSharedAtisUpdateSound)
+                    {
+                        NativeAudio.EmitSound(SoundType.Notification);
+                    }
                 }
 
                 AtisLetter = sync.Dto.AtisLetter;
@@ -1391,7 +1395,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             if (e.IsNewMetar)
             {
                 IsNewAtis = false;
-                if (!_appConfig.SuppressNotificationSound)
+                if (!_appConfig.MuteOwnAtisUpdateSound)
                 {
                     NativeAudio.EmitSound(SoundType.Notification);
                 }

--- a/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
@@ -116,7 +116,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether notification sounds should be suppressed.
+    /// Gets or sets a value indicating whether notification sounds for the user's own ATIS updates should be muted.
     /// </summary>
     public bool MuteOwnAtisUpdateSound
     {
@@ -125,7 +125,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether notification sounds for observed ATIS should be suppressed.
+    /// Gets or sets a value indicating whether notification sounds for shared ATIS updates should be muted.
     /// </summary>
     public bool MuteSharedAtisUpdateSound
     {

--- a/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
@@ -26,7 +26,8 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     private string? _password;
     private string? _selectedNetworkRating;
     private ObservableCollection<ComboBoxItemMeta>? _networkRatings;
-    private bool _suppressNotificationSound;
+    private bool _muteOwnAtisUpdateSound;
+    private bool _muteSharedAtisUpdateSound;
     private bool _autoFetchAtisLetter;
 
     /// <summary>
@@ -40,7 +41,8 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         Name = _appConfig.Name;
         UserId = _appConfig.UserId;
         Password = _appConfig.PasswordDecrypted;
-        SuppressNotificationSound = _appConfig.SuppressNotificationSound;
+        MuteOwnAtisUpdateSound = _appConfig.MuteOwnAtisUpdateSound;
+        MuteSharedAtisUpdateSound = _appConfig.MuteSharedAtisUpdateSound;
         SelectedNetworkRating = _appConfig.NetworkRating.ToString();
         AutoFetchAtisLetter = _appConfig.AutoFetchAtisLetter;
 
@@ -116,10 +118,19 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     /// <summary>
     /// Gets or sets a value indicating whether notification sounds should be suppressed.
     /// </summary>
-    public bool SuppressNotificationSound
+    public bool MuteOwnAtisUpdateSound
     {
-        get => _suppressNotificationSound;
-        set => this.RaiseAndSetIfChanged(ref _suppressNotificationSound, value);
+        get => _muteOwnAtisUpdateSound;
+        set => this.RaiseAndSetIfChanged(ref _muteOwnAtisUpdateSound, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether notification sounds for observed ATIS should be suppressed.
+    /// </summary>
+    public bool MuteSharedAtisUpdateSound
+    {
+        get => _muteSharedAtisUpdateSound;
+        set => this.RaiseAndSetIfChanged(ref _muteSharedAtisUpdateSound, value);
     }
 
     /// <summary>
@@ -144,7 +155,8 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         _appConfig.Name = Name ?? "";
         _appConfig.UserId = UserId?.Trim() ?? "";
         _appConfig.PasswordDecrypted = Password?.Trim() ?? "";
-        _appConfig.SuppressNotificationSound = SuppressNotificationSound;
+        _appConfig.MuteOwnAtisUpdateSound = MuteOwnAtisUpdateSound;
+        _appConfig.MuteSharedAtisUpdateSound = MuteSharedAtisUpdateSound;
         _appConfig.AutoFetchAtisLetter = AutoFetchAtisLetter;
 
         if (Enum.TryParse(SelectedNetworkRating, out NetworkRating selectedNetworkRating))


### PR DESCRIPTION
- Add notification sound for shared ATIS updates
- Add user setting to independently mute shared/owned ATIS updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate mute options for own ATIS update sounds and shared ATIS update sounds, allowing users to control each notification independently in the settings.

- **User Interface**
  - Updated the settings dialog to provide two distinct checkboxes for muting own and shared ATIS update sounds, improving customization of notification preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->