### PR TITLE
Add color state to Record ATIS button

### DIFF
--- a/vATIS.Desktop/Atis/RecordedAtisState.cs
+++ b/vATIS.Desktop/Atis/RecordedAtisState.cs
@@ -1,0 +1,27 @@
+// <copyright file="RecordedAtisState.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Atis;
+
+/// <summary>
+/// Specifies the possible statuses for a manually recorded ATIS.
+/// </summary>
+public enum RecordedAtisState
+{
+    /// <summary>
+    /// ATIS is not currently connected or broadcasting.
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// ATIS is currently connected and actively broadcasting.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// ATIS recording has expired and needs to be updated.
+    /// </summary>
+    Expired
+}

--- a/vATIS.Desktop/Ui/Behaviors/RecordAtisButtonBehavior.cs
+++ b/vATIS.Desktop/Ui/Behaviors/RecordAtisButtonBehavior.cs
@@ -1,0 +1,186 @@
+// <copyright file="RecordAtisButtonBehavior.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactivity;
+using Vatsim.Vatis.Atis;
+
+namespace Vatsim.Vatis.Ui.Behaviors;
+
+/// <summary>
+/// A behavior that enables a blinking background effect on the RECORD ATIS button.
+/// </summary>
+public class RecordAtisButtonBehavior : Behavior<Button>
+{
+    /// <summary>
+    /// Identifies the <see cref="RecordedAtisState"/> property.
+    /// </summary>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<RecordedAtisState> RecordedAtisStateProperty =
+        AvaloniaProperty.Register<RecordAtisButtonBehavior, RecordedAtisState>(nameof(RecordedAtisState));
+
+    /// <summary>
+    /// Identifies the <see cref="BlinkOnColor"/> property.
+    /// </summary>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<IBrush> BlinkOnColorProperty =
+        AvaloniaProperty.Register<RecordAtisButtonBehavior, IBrush>(nameof(BlinkOnColor), Brushes.Gold);
+
+    /// <summary>
+    /// Identifies the <see cref="BlinkOffColor"/> property.
+    /// </summary>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<IBrush> BlinkOffColorProperty =
+        AvaloniaProperty.Register<RecordAtisButtonBehavior, IBrush>(nameof(BlinkOffColor), Brushes.Aqua);
+
+    /// <summary>
+    /// Identifies the <see cref="BlinkDuration"/> property.
+    /// </summary>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static readonly StyledProperty<TimeSpan> BlinkDurationProperty =
+        AvaloniaProperty.Register<RecordAtisButtonBehavior, TimeSpan>(nameof(BlinkDuration), TimeSpan.FromSeconds(60));
+
+    private static readonly SolidColorBrush s_grayBrush = new(Color.FromRgb(50, 50, 50));
+    private static readonly SolidColorBrush s_blueBrush = new(Color.FromRgb(0, 70, 150));
+    private static readonly List<RecordAtisButtonBehavior> s_instances = [];
+    private static bool s_isBlinking;
+    private CancellationTokenSource? _blinkCts;
+
+    static RecordAtisButtonBehavior()
+    {
+        DispatcherTimer.Run(OnTimerTick, TimeSpan.FromMilliseconds(500));
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the blinking effect is active.
+    /// </summary>
+    public RecordedAtisState RecordedAtisState
+    {
+        get => GetValue(RecordedAtisStateProperty);
+        set => SetValue(RecordedAtisStateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the brush used for the "on" blink state.
+    /// </summary>
+    public IBrush BlinkOnColor
+    {
+        get => GetValue(BlinkOnColorProperty);
+        set => SetValue(BlinkOnColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the brush used for the "off" blink state.
+    /// </summary>
+    public IBrush BlinkOffColor
+    {
+        get => GetValue(BlinkOffColorProperty);
+        set => SetValue(BlinkOffColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the duration that the control will blink before reverting
+    /// to its original foreground color.
+    /// </summary>
+    public TimeSpan BlinkDuration
+    {
+        get => GetValue(BlinkDurationProperty);
+        set => SetValue(BlinkDurationProperty, value);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        if (AssociatedObject is null)
+        {
+            return;
+        }
+
+        s_instances.Add(this);
+
+        this.GetObservable(RecordedAtisStateProperty).Subscribe(state =>
+        {
+            if (state != RecordedAtisState.Connected)
+                return;
+
+            _blinkCts?.Cancel();
+            _blinkCts = new CancellationTokenSource();
+            var token = _blinkCts.Token;
+
+            // Capture BlinkDuration from UI thread
+            var blinkDuration = BlinkDuration;
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(blinkDuration, token);
+
+                    if (!token.IsCancellationRequested)
+                    {
+                        Dispatcher.UIThread.Post(() => s_isBlinking = false);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    // Ignore
+                }
+            }, token);
+        });
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+
+        _blinkCts?.Cancel();
+        _blinkCts?.Dispose();
+        _blinkCts = null;
+
+        if (AssociatedObject is null)
+        {
+            return;
+        }
+
+        AssociatedObject.Background = s_grayBrush;
+        s_instances.Remove(this);
+    }
+
+    private static bool OnTimerTick()
+    {
+        s_isBlinking = !s_isBlinking;
+
+        foreach (var instance in s_instances)
+        {
+            if (instance.AssociatedObject is null)
+            {
+                continue;
+            }
+
+            if (instance.RecordedAtisState == RecordedAtisState.Expired)
+            {
+                instance.AssociatedObject.Background = s_isBlinking ? instance.BlinkOnColor : instance.BlinkOffColor;
+            }
+            else
+            {
+                instance.AssociatedObject.Background = instance.RecordedAtisState == RecordedAtisState.Connected
+                    ? s_blueBrush
+                    : s_grayBrush;
+            }
+        }
+
+        return true;
+    }
+}

--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml
@@ -77,7 +77,11 @@
 			<!--Bottom Toolbar-->
 			<Grid Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="2" Margin="0,10,0,0" ColumnDefinitions="120,*,120"
 			      RowDefinitions="30">
-				<Button Command="{Binding VoiceRecordAtisCommand, DataType=vm:AtisStationViewModel}" Theme="{StaticResource Dark}" Content="RECORD ATIS" Grid.Column="0" Margin="0,0,5,0"/>
+				<Button Command="{Binding VoiceRecordAtisCommand, DataType=vm:AtisStationViewModel}" Theme="{StaticResource Dark}" Content="RECORD ATIS" Grid.Column="0" Margin="0,0,5,0">
+                    <Interaction.Behaviors>
+                        <behaviors:RecordAtisButtonBehavior RecordedAtisState="{Binding RecordedAtisState, DataType=vm:AtisStationViewModel}" BlinkOnColor="#004696" BlinkOffColor="#323232"/>
+                    </Interaction.Behaviors>
+                </Button>
 				<controls:NonNavigableComboBox Name="AtisPreset" Classes="Dark" Grid.Column="1" Margin="0,-1,0,0" ItemsSource="{Binding AtisPresetList, DataType=vm:AtisStationViewModel}" DisplayMemberBinding="{Binding Name, DataType=models:AtisPreset}" SelectedItem="{Binding SelectedAtisPreset, DataType=vm:AtisStationViewModel, Mode=OneWay}">
 					<ComboBox.Styles>
 						<Style Selector="ComboBox.Dark /template/ Grid">

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -100,6 +100,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private TextDocument? _airportConditionsTextDocument = new();
     private TextDocument? _notamsTextDocument = new();
     private bool _useTexToSpeech;
+    private RecordedAtisState _recordedAtisState = RecordedAtisState.Disconnected;
     private NetworkConnectionStatus _networkConnectionStatus = NetworkConnectionStatus.Disconnected;
     private List<ICompletionData> _contractionCompletionData = [];
     private bool _hasUnsavedAirportConditions;
@@ -630,6 +631,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the status of a manually recorded ATIS.
+    /// </summary>
+    public RecordedAtisState RecordedAtisState
+    {
+        get => _recordedAtisState;
+        set => this.RaiseAndSetIfChanged(ref _recordedAtisState, value);
+    }
+
+    /// <summary>
     /// Gets or sets the collection of contraction completion data used for auto-completion.
     /// </summary>
     public List<ICompletionData> ContractionCompletionData
@@ -710,6 +720,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
         // Set network connection status as disconnected
         NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;
+        RecordedAtisState = RecordedAtisState.Disconnected;
     }
 
     /// <summary>
@@ -1064,6 +1075,9 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                             // Send the DTO to the voice server
                             await _voiceServerConnection.AddOrUpdateBot(_networkConnection.Callsign, dto,
                                 localToken.Token);
+
+                            RecordedAtisState = RecordedAtisState.Connected;
+                            IsNewAtis = false;
                         }
                         catch (OperationCanceledException)
                         {
@@ -1404,6 +1418,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                 await AcknowledgeOrIncrementAtisLetterCommand.Execute();
                 IsNewAtis = true;
+                RecordedAtisState = RecordedAtisState.Expired;
             }
 
             // Save the decoded metar so its individual properties can be sent to clients


### PR DESCRIPTION
- Blue if recorded ATIS is connected and broadcasting
- Blinking blue if the recorded ATIS is expired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visual blinking effect to the "RECORD ATIS" button, providing clear feedback based on the ATIS recording state (Disconnected, Connected, Expired).
  - The button now changes color and blinks to indicate when a new ATIS recording is needed or when it is actively broadcasting.
- **Enhancements**
  - The ATIS recording state is now visibly tracked and updated in the interface for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->