### PR TITLE
Fix message type for getActiveProfile and getContractions WS response

### DIFF
--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/ActiveProfileMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/ActiveProfileMessage.cs
@@ -16,7 +16,7 @@ public class ActiveProfileMessage
     /// Gets the string identifying the message type.
     /// </summary>
     [JsonPropertyName("type")]
-    public string MessageType => "getActiveProfile";
+    public string MessageType => "activeProfile";
 
     /// <summary>
     /// Gets or sets the ID of the active profile.

--- a/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
+++ b/vATIS.Desktop/Ui/Services/Websocket/Messages/ContractionsResponseMessage.cs
@@ -18,7 +18,7 @@ public class ContractionsResponseMessage
     /// Gets the string identifying the message type.
     /// </summary>
     [JsonPropertyName("type")]
-    public string MessageType => "getContractions";
+    public string MessageType => "contractions";
 
     /// <summary>
     /// Gets or sets a list of stations and their contractions.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal message type identifiers for improved consistency in profile and contractions messages. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->