### PR TITLE
Toggle display of ATIS stations in mini-display

### DIFF
--- a/vATIS.Desktop/Atis/Nodes/CloudNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/CloudNode.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Vatsim.Vatis.Atis.Extensions;
-using Vatsim.Vatis.Weather;
 using Vatsim.Vatis.Weather.Decoder.Entity;
 using Vatsim.Vatis.Weather.Extensions;
 

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -109,6 +109,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private bool _hasUnsavedNotams;
     private string? _previousFreeTextNotams;
     private string? _previousFreeTextAirportConditions;
+    private bool _isVisibleOnMiniWindow = true;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AtisStationViewModel"/> class.
@@ -280,7 +281,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                      !string.Equals(sync.Dto.Metar, Metar, StringComparison.OrdinalIgnoreCase)))
                 {
                     IsNewAtis = true;
-                    if (!_appConfig.MuteSharedAtisUpdateSound)
+                    if (!_appConfig.MuteSharedAtisUpdateSound && IsVisibleOnMiniWindow)
                     {
                         NativeAudio.EmitSound(SoundType.Notification);
                     }
@@ -666,6 +667,15 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _hasUnsavedNotams;
         set => this.RaiseAndSetIfChanged(ref _hasUnsavedNotams, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the station is visible on the mini-window.
+    /// </summary>
+    public bool IsVisibleOnMiniWindow
+    {
+        get => _isVisibleOnMiniWindow;
+        set => this.RaiseAndSetIfChanged(ref _isVisibleOnMiniWindow, value);
     }
 
     /// <summary>
@@ -1413,7 +1423,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             if (e.IsNewMetar)
             {
                 IsNewAtis = false;
-                if (!_appConfig.MuteOwnAtisUpdateSound)
+                if (!_appConfig.MuteOwnAtisUpdateSound && IsVisibleOnMiniWindow)
                 {
                     NativeAudio.EmitSound(SoundType.Notification);
                 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -44,7 +44,6 @@ using Vatsim.Vatis.Ui.Services.Websocket.Messages;
 using Vatsim.Vatis.Voice.Audio;
 using Vatsim.Vatis.Voice.Network;
 using Vatsim.Vatis.Voice.Utils;
-using Vatsim.Vatis.Weather;
 using Vatsim.Vatis.Weather.Decoder;
 using Vatsim.Vatis.Weather.Decoder.Entity;
 using Vatsim.Vatis.Weather.Extensions;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -275,14 +275,20 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
             Dispatcher.UIThread.Post(() =>
             {
-                if (NetworkConnectionStatus == NetworkConnectionStatus.Observer &&
-                    (sync.Dto.AtisLetter != AtisLetter ||
-                     !string.Equals(sync.Dto.Metar, Metar, StringComparison.OrdinalIgnoreCase)))
+                if (NetworkConnectionStatus == NetworkConnectionStatus.Observer)
                 {
-                    IsNewAtis = true;
-                    if (!_appConfig.MuteSharedAtisUpdateSound && IsVisibleOnMiniWindow)
+                    var atisLetterChanged = sync.Dto.AtisLetter != AtisLetter;
+                    var metarChanged = !string.IsNullOrEmpty(sync.Dto.Metar) &&
+                                       !string.Equals(sync.Dto.Metar, Metar, StringComparison.OrdinalIgnoreCase);
+
+                    if (atisLetterChanged || metarChanged)
                     {
-                        NativeAudio.EmitSound(SoundType.Notification);
+                        IsNewAtis = true;
+
+                        if (!_appConfig.MuteSharedAtisUpdateSound && IsVisibleOnMiniWindow)
+                        {
+                            NativeAudio.EmitSound(SoundType.Notification);
+                        }
                     }
                 }
 

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
@@ -28,6 +29,7 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     private readonly IWindowLocationService _windowLocationService;
     private IDialogOwner? _dialogOwner;
     private ReadOnlyObservableCollection<AtisStationViewModel> _stations = new([]);
+    private ReadOnlyObservableCollection<AtisStationViewModel> _filteredStations = new([]);
     private bool _isControlsVisible;
 
     /// <summary>
@@ -61,6 +63,15 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _stations;
         set => this.RaiseAndSetIfChanged(ref _stations, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the collection of filtered ATIS station view models displayed in the compact window.
+    /// </summary>
+    public ReadOnlyObservableCollection<AtisStationViewModel> FilteredStations
+    {
+        get => _filteredStations;
+        set => this.RaiseAndSetIfChanged(ref _filteredStations, value);
     }
 
     /// <summary>

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
@@ -31,8 +31,9 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     private readonly CompositeDisposable _disposables = [];
     private readonly ISessionManager _sessionManager;
     private readonly IWindowLocationService _windowLocationService;
+    private readonly ObservableCollection<AtisStationViewModel> _filteredStationsSource = [];
     private ReadOnlyObservableCollection<AtisStationViewModel> _stations = new([]);
-    private ReadOnlyObservableCollection<AtisStationViewModel> _filteredStations = new([]);
+    private ReadOnlyObservableCollection<AtisStationViewModel> _filteredStations;
     private IDialogOwner? _dialogOwner;
     private bool _isControlsVisible;
     private bool _hasAnyStations;
@@ -48,6 +49,8 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     {
         _sessionManager = sessionManager;
         _windowLocationService = windowLocationService;
+
+        _filteredStations = new ReadOnlyObservableCollection<AtisStationViewModel>(_filteredStationsSource);
 
         InvokeMainWindowCommand = ReactiveCommand.Create<ICloseable>(InvokeMainWindow);
         EndClientSessionCommand = ReactiveCommand.CreateFromTask(HandleEndClientSession);
@@ -157,8 +160,13 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
                     .Where(x => x.IsVisibleOnMiniWindow)
                     .ToList();
 
-                FilteredStations = new ReadOnlyObservableCollection<AtisStationViewModel>(
-                    new ObservableCollection<AtisStationViewModel>(filteredOnlineStations));
+                _filteredStationsSource.Clear();
+                foreach (var station in filteredOnlineStations)
+                {
+                    _filteredStationsSource.Add(station);
+                }
+
+                FilteredStations = _filteredStations;
 
                 if (!allOnlineStations.Any())
                 {

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;

--- a/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/CompactWindowViewModel.cs
@@ -7,12 +7,16 @@ using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using DynamicData;
+using DynamicData.Binding;
 using ReactiveUI;
 using Vatsim.Vatis.Networking;
+using Vatsim.Vatis.Profiles.Models;
 using Vatsim.Vatis.Sessions;
 using Vatsim.Vatis.Ui.Dialogs.MessageBox;
 using Vatsim.Vatis.Ui.Services;
@@ -24,12 +28,16 @@ namespace Vatsim.Vatis.Ui.ViewModels;
 /// </summary>
 public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
 {
+    private readonly CompositeDisposable _disposables = [];
     private readonly ISessionManager _sessionManager;
     private readonly IWindowLocationService _windowLocationService;
-    private IDialogOwner? _dialogOwner;
     private ReadOnlyObservableCollection<AtisStationViewModel> _stations = new([]);
     private ReadOnlyObservableCollection<AtisStationViewModel> _filteredStations = new([]);
+    private IDialogOwner? _dialogOwner;
     private bool _isControlsVisible;
+    private bool _hasAnyStations;
+    private bool _statusLabelVisible;
+    private string? _statusLabel;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompactWindowViewModel"/> class.
@@ -56,7 +64,34 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     public ReactiveCommand<Unit, bool> EndClientSessionCommand { get; }
 
     /// <summary>
-    /// Gets or sets the collection of ATIS station view models displayed in the compact window.
+    /// Gets or sets a value indicating whether there are any ATIS stations associated with the profile.
+    /// </summary>
+    public bool HasAnyStations
+    {
+        get => _hasAnyStations;
+        set => this.RaiseAndSetIfChanged(ref _hasAnyStations, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <see cref="StatusLabel"/> should be shown.
+    /// </summary>
+    public bool StatusLabelVisible
+    {
+        get => _statusLabelVisible;
+        set => this.RaiseAndSetIfChanged(ref _statusLabelVisible, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the label that describes the current connection status of the mini-window.
+    /// </summary>
+    public string? StatusLabel
+    {
+        get => _statusLabel;
+        set => this.RaiseAndSetIfChanged(ref _statusLabel, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the list of all connected ATIS stations.
     /// </summary>
     public ReadOnlyObservableCollection<AtisStationViewModel> Stations
     {
@@ -65,7 +100,7 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Gets or sets the collection of filtered ATIS station view models displayed in the compact window.
+    /// Gets or sets the filtered list of connected ATIS stations that are visible on the mini window.
     /// </summary>
     public ReadOnlyObservableCollection<AtisStationViewModel> FilteredStations
     {
@@ -81,6 +116,69 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     {
         get => _isControlsVisible;
         set => this.RaiseAndSetIfChanged(ref _isControlsVisible, value);
+    }
+
+    /// <summary>
+    /// Initializes the connection to a shared source of <see cref="AtisStationViewModel"/>s.
+    /// Binds connected stations to <see cref="Stations"/> and filters visible stations to <see cref="FilteredStations"/>.
+    /// Also updates the <see cref="StatusLabel"/> and <see cref="StatusLabelVisible"/> properties based on connection and visibility status.
+    /// </summary>
+    /// <param name="sharedSource">The shared source list containing ATIS station view models.</param>
+    public void Initialize(SourceList<AtisStationViewModel> sharedSource)
+    {
+        sharedSource.Connect()
+            .AutoRefresh(x => x.NetworkConnectionStatus)
+            .AutoRefresh(x => x.Ordinal)
+            .AutoRefresh(x => x.IsVisibleOnMiniWindow)
+            .Sort(SortExpressionComparer<AtisStationViewModel>
+                .Ascending(i => i.Ordinal)
+                .ThenBy(i => i.Identifier ?? string.Empty)
+                .ThenBy(i => i.AtisType switch
+                {
+                    AtisType.Combined => 0,
+                    AtisType.Arrival => 1,
+                    AtisType.Departure => 2,
+                    _ => 3
+                }))
+            .Bind(out var stations)
+            .Subscribe(_ =>
+            {
+                Stations = stations;
+                HasAnyStations = stations.Any();
+
+                // All online stations (regardless of user filtering)
+                var allOnlineStations = stations
+                    .Where(x => x.NetworkConnectionStatus is NetworkConnectionStatus.Connected
+                        or NetworkConnectionStatus.Observer)
+                    .ToList();
+
+                // Filtered stations (user-selected visibility + online)
+                var filteredOnlineStations = allOnlineStations
+                    .Where(x => x.IsVisibleOnMiniWindow)
+                    .ToList();
+
+                FilteredStations = new ReadOnlyObservableCollection<AtisStationViewModel>(
+                    new ObservableCollection<AtisStationViewModel>(filteredOnlineStations));
+
+                if (!allOnlineStations.Any())
+                {
+                    // All ATISes are offline
+                    StatusLabel = "NO ATISES ONLINE";
+                    StatusLabelVisible = true;
+                }
+                else if (!filteredOnlineStations.Any())
+                {
+                    // Some ATISes are online, but user hasn't made any visible
+                    StatusLabel = "NO FILTERED ATISES";
+                    StatusLabelVisible = true;
+                }
+                else
+                {
+                    StatusLabel = string.Empty;
+                    StatusLabelVisible = false;
+                }
+            })
+            .DisposeWith(_disposables);
     }
 
     /// <summary>
@@ -119,6 +217,7 @@ public class CompactWindowViewModel : ReactiveViewModelBase, IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        _disposables.Dispose();
         InvokeMainWindowCommand.Dispose();
         EndClientSessionCommand.Dispose();
         GC.SuppressFinalize(this);

--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -137,54 +137,6 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
 
         AtisStations = sortedStations;
 
-        _atisStationSource.Connect()
-            .AutoRefresh(x => x.NetworkConnectionStatus)
-            .AutoRefresh(x => x.Ordinal)
-            .AutoRefresh(x => x.IsVisibleOnMiniWindow)
-            .Filter(x => x is
-            {
-                IsVisibleOnMiniWindow: true,
-                NetworkConnectionStatus: NetworkConnectionStatus.Connected or NetworkConnectionStatus.Observer
-            })
-            .Sort(SortExpressionComparer<AtisStationViewModel>
-                .Ascending(i => i.Ordinal)
-                .ThenBy(i => i.Identifier ?? string.Empty)
-                .ThenBy(i => i.AtisType switch
-                {
-                    AtisType.Combined => 0,
-                    AtisType.Arrival => 1,
-                    AtisType.Departure => 2,
-                    _ => 3
-                }))
-            .Bind(out var filteredConnectedStations)
-            .Subscribe(_ => { FilteredCompactWindowStations = filteredConnectedStations; })
-            .DisposeWith(_disposables);
-
-        FilteredCompactWindowStations = filteredConnectedStations;
-
-        _atisStationSource.Connect()
-            .AutoRefresh(x => x.NetworkConnectionStatus)
-            .AutoRefresh(x => x.Ordinal)
-            .Filter(x => x is
-            {
-                NetworkConnectionStatus: NetworkConnectionStatus.Connected or NetworkConnectionStatus.Observer
-            })
-            .Sort(SortExpressionComparer<AtisStationViewModel>
-                .Ascending(i => i.Ordinal)
-                .ThenBy(i => i.Identifier ?? string.Empty)
-                .ThenBy(i => i.AtisType switch
-                {
-                    AtisType.Combined => 0,
-                    AtisType.Arrival => 1,
-                    AtisType.Departure => 2,
-                    _ => 3
-                }))
-            .Bind(out var connectedStations)
-            .Subscribe(_ => { CompactWindowStations = connectedStations; })
-            .DisposeWith(_disposables);
-
-        CompactWindowStations = connectedStations;
-
         _disposables.Add(EventBus.Instance.Subscribe<OpenGenerateSettingsDialog>(_ => OpenSettingsDialog()));
         _disposables.Add(EventBus.Instance.Subscribe<AtisStationAdded>(evt =>
         {
@@ -258,16 +210,6 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
     /// Gets or sets the collection of ATIS station view models to display in the tab control.
     /// </summary>
     public ReadOnlyObservableCollection<AtisStationViewModel> AtisStations { get; set; }
-
-    /// <summary>
-    /// Gets or sets the filtered collection of ATIS stations displayed in the compact window context menu.
-    /// </summary>
-    public ReadOnlyObservableCollection<AtisStationViewModel> CompactWindowStations { get; set; }
-
-    /// <summary>
-    /// Gets or sets the filtered collection of ATIS stations displayed in the compact window.
-    /// </summary>
-    public ReadOnlyObservableCollection<AtisStationViewModel> FilteredCompactWindowStations { get; set; }
 
     /// <summary>
     /// Gets the command to open the settings dialog.
@@ -470,8 +412,7 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
         var compactView = _windowFactory.CreateCompactWindow();
         if (compactView.DataContext is CompactWindowViewModel context)
         {
-            context.Stations = CompactWindowStations;
-            context.FilteredStations = FilteredCompactWindowStations;
+            context.Initialize(_atisStationSource);
         }
 
         compactView.Show();

--- a/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/MainWindowViewModel.cs
@@ -183,7 +183,7 @@ public class MainWindowViewModel : ReactiveViewModelBase, IDisposable
             .Subscribe(_ => { CompactWindowStations = connectedStations; })
             .DisposeWith(_disposables);
 
-        CompactWindowStations = filteredConnectedStations;
+        CompactWindowStations = connectedStations;
 
         _disposables.Add(EventBus.Instance.Subscribe<OpenGenerateSettingsDialog>(_ => OpenSettingsDialog()));
         _disposables.Add(EventBus.Instance.Subscribe<AtisStationAdded>(evt =>

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -60,7 +60,7 @@
             Background="#323232"
             ClipToBounds="True">
         <Border.ContextMenu>
-            <ContextMenu ItemsSource="{Binding Stations, DataType=vm:CompactWindowViewModel}" IsVisible="{Binding Stations.Count, DataType=vm:CompactWindowViewModel}">
+            <ContextMenu ItemsSource="{Binding Stations, DataType=vm:CompactWindowViewModel}" IsVisible="{Binding HasAnyStations, DataType=vm:CompactWindowViewModel}">
                 <ContextMenu.ItemTemplate>
                     <DataTemplate>
                         <CheckBox IsChecked="{Binding IsVisibleOnMiniWindow, DataType=vm:AtisStationViewModel}" Content="{Binding TabText, DataType=vm:AtisStationViewModel}" Theme="{StaticResource CheckBox}"/>
@@ -111,10 +111,10 @@
             <TextBlock VerticalAlignment="Center"
                        HorizontalAlignment="Center"
                        Foreground="White"
-                       FontSize="24"
+                       FontSize="20"
                        Margin="10"
-                       IsVisible="{Binding !Stations.Count, DataType=vm:CompactWindowViewModel, FallbackValue=False}"
-                       Text="NOT CONNECTED"/>
+                       IsVisible="{Binding StatusLabelVisible, DataType=vm:CompactWindowViewModel, FallbackValue=False}"
+                       Text="{Binding StatusLabel, DataType=vm:CompactWindowViewModel}"/>
         </Panel>
     </Border>
 </Window>

--- a/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/CompactWindow.axaml
@@ -59,13 +59,35 @@
             BorderThickness="1"
             Background="#323232"
             ClipToBounds="True">
+        <Border.ContextMenu>
+            <ContextMenu ItemsSource="{Binding Stations, DataType=vm:CompactWindowViewModel}" IsVisible="{Binding Stations.Count, DataType=vm:CompactWindowViewModel}">
+                <ContextMenu.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox IsChecked="{Binding IsVisibleOnMiniWindow, DataType=vm:AtisStationViewModel}" Content="{Binding TabText, DataType=vm:AtisStationViewModel}" Theme="{StaticResource CheckBox}"/>
+                    </DataTemplate>
+                </ContextMenu.ItemTemplate>
+                <ContextMenu.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Spacing="-5" />
+                    </ItemsPanelTemplate>
+                </ContextMenu.ItemsPanel>
+                <ContextMenu.Styles>
+                    <Style Selector="MenuItem">
+                        <Setter Property="Padding" Value="5,0"/>
+                    </Style>
+                    <Style Selector="MenuItem:pointerover /template/ Border#PART_LayoutRoot">
+                        <Setter Property="Background" Value="Transparent"/>
+                    </Style>
+                </ContextMenu.Styles>
+            </ContextMenu>
+        </Border.ContextMenu>
         <Panel ClipToBounds="True">
             <StackPanel Name="WindowControls" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" Spacing="3" ZIndex="1" Margin="3" IsVisible="{Binding IsControlsVisible, DataType=vm:CompactWindowViewModel}">
                 <ToggleButton Theme="{StaticResource ActionToggle}" Command="{Binding ToggleMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" IsChecked="{Binding ShowMetarDetails, DataType=vm:CompactWindowTopMostViewModel, Mode=OneWay, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" />
                 <ToggleButton Theme="{StaticResource PinButtonSmall}" Command="{Binding ToggleIsTopMost, DataType=vm:CompactWindowTopMostViewModel, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" IsChecked="{Binding IsTopMost, DataType=vm:CompactWindowTopMostViewModel, Mode=OneWay, Source={x:Static vm:CompactWindowTopMostViewModel.Instance}}" />
                 <Button Theme="{StaticResource CompactViewButtonSmall}" Command="{Binding InvokeMainWindowCommand, DataType=vm:CompactWindowViewModel}" CommandParameter="{Binding ElementName=Window}" />
             </StackPanel>
-            <ItemsControl ItemsSource="{Binding Stations, DataType=vm:CompactWindowViewModel}" Margin="5" IsVisible="{Binding Stations.Count, DataType=vm:CompactWindowViewModel}" VerticalAlignment="Center">
+            <ItemsControl ItemsSource="{Binding FilteredStations, DataType=vm:CompactWindowViewModel}" Margin="5" IsVisible="{Binding FilteredStations.Count, DataType=vm:CompactWindowViewModel}" VerticalAlignment="Center">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal" Spacing="5">


### PR DESCRIPTION
Add support for toggling display of individual ATIS stations in the mini-display window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to show or hide individual stations in the compact window using a context menu with checkboxes.
	- The compact window now displays only the stations marked as visible, allowing for a more customized view.
- **Improvements**
	- Notification sounds for ATIS and METAR updates are now only played for stations that are visible in the compact window.
	- Enhanced station filtering and status labeling in the compact window for clearer connectivity information.
	- Simplified station management by directly initializing the compact window with the full list of stations.
- **User Interface**
	- The compact window features a new context menu for managing station visibility.
	- The station list in the compact window updates dynamically based on visibility selections.
	- Status messages and font sizes in the compact window have been refined for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->