### PR TITLE
Fix heartbeat timer

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1211,14 +1211,14 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private async Task DisconnectFromVoiceServer()
     {
-        if (_voiceServerConnection == null || _networkConnection == null)
+        if (_voiceServerConnection == null)
             return;
 
         try
         {
             if (NetworkConnectionStatus == NetworkConnectionStatus.Connected)
             {
-                await _voiceServerConnection.RemoveBot(_networkConnection.Callsign);
+                await _voiceServerConnection.RemoveBot(_networkConnection?.Callsign);
 
                 await _atisHubConnection.DisconnectAtis(new AtisHubDto(AtisStation.Identifier, AtisStation.AtisType,
                     AtisLetter));

--- a/vATIS.Desktop/Voice/Network/IVoiceServerConnection.cs
+++ b/vATIS.Desktop/Voice/Network/IVoiceServerConnection.cs
@@ -34,7 +34,7 @@ public interface IVoiceServerConnection
     /// <param name="dto">The details of the bot, including transceivers and audio settings.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task AddOrUpdateBot(string callsign, PutBotRequestDto dto, CancellationToken cancellationToken);
+    Task AddOrUpdateBot(string? callsign, PutBotRequestDto dto, CancellationToken cancellationToken);
 
     /// <summary>
     /// Removes the bot associated with the specified callsign from the voice server.
@@ -42,5 +42,5 @@ public interface IVoiceServerConnection
     /// <param name="callsign">The callsign of the bot to be removed.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task RemoveBot(string callsign, CancellationToken? cancellationToken = null);
+    Task RemoveBot(string? callsign, CancellationToken? cancellationToken = null);
 }


### PR DESCRIPTION
Fix issue with heartbeat timer not stopping when ATIS is forcefully disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of potential errors when disconnecting from the voice server, reducing the chance of unexpected crashes.
- **Refactor**
	- Enhanced validation and error checking for callsign values when adding, updating, or removing bots from the voice server.
	- Improved resource cleanup during voice server disconnection for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->