### PR TITLE
Fix Record ATIS button blink state

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1435,7 +1435,11 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                 await AcknowledgeOrIncrementAtisLetterCommand.Execute();
                 IsNewAtis = true;
-                RecordedAtisState = RecordedAtisState.Expired;
+
+                if (!AtisStation.AtisVoice.UseTextToSpeech)
+                {
+                    RecordedAtisState = RecordedAtisState.Expired;
+                }
             }
 
             // Save the decoded metar so its individual properties can be sent to clients


### PR DESCRIPTION
The Record ATIS button should only blink if the ATIS is configured to be manually recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of ATIS state updates when receiving new METARs, ensuring correct behavior based on the voice configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->