### PR TITLE
Fix value cannot be null exception

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -1363,8 +1363,6 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
     private void OnNetworkDisconnected(object? sender, NetworkDisconnectedReceived e)
     {
-        _decodedMetar = null;
-
         Dispatcher.UIThread.Post(() =>
         {
             NetworkConnectionStatus = NetworkConnectionStatus.Disconnected;


### PR DESCRIPTION
A rare race condition occurs when the user connects, disconnects, and then quickly reconnects an ATIS. During this sequence, the BuildAtis method may be triggered before _decodedMetar has been properly initialized, resulting in a null reference and an incomplete ATIS build. There's no need to set the _decodedMetar to null after disconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of METAR data during network disconnections to prevent unnecessary data clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->