### PR TITLE
Fix ATIS station sort logic

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -533,7 +533,8 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
                         return;
                     }
 
-                    context.AtisStations = new ObservableCollection<AtisStation>(_atisStationSource.Items);
+                    context.AtisStations =
+                        new ObservableCollection<AtisStation>(_atisStationSource.Items.OrderBy(x => x.Ordinal));
                     context.AtisStations.CollectionChanged += (_, _) =>
                     {
                         try

--- a/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SortAtisStationsDialogViewModel.cs
@@ -75,8 +75,8 @@ public class SortAtisStationsDialogViewModel : ReactiveViewModelBase, IDisposabl
         get => _stations;
         set
         {
+            Source.Items = value;
             this.RaiseAndSetIfChanged(ref _stations, value);
-            Source.Items = _stations.OrderBy(x => x.Ordinal);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stations in the sort dialog are now displayed in the correct order based on their ordinal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->