### PR TITLE
Automatically apply airport conditions and NOTAMs

### DIFF
--- a/vATIS.Desktop/Ui/Components/AtisStationView.axaml
+++ b/vATIS.Desktop/Ui/Components/AtisStationView.axaml
@@ -52,9 +52,7 @@
 					</Interaction.Behaviors>
                     <editor:TextEditor.ContextMenu>
                         <ContextMenu IsEnabled="{Binding HasUnsavedAirportConditions, DataType=vm:AtisStationViewModel}">
-                            <MenuItem Header="Apply Without Saving" ToolTip.Tip="Temporarily apply changes to the ATIS without saving them to the profile" Command="{Binding ApplyAirportConditionsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:False}"/>
-                            <Separator/>
-                            <MenuItem Header="Save and Apply" ToolTip.Tip="Save changes to the profile and apply them to the ATIS" Command="{Binding ApplyAirportConditionsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
+                            <MenuItem Header="Save Airport Conditions" ToolTip.Tip="Save the airport conditions to the ATIS profile." Command="{Binding ApplyAirportConditionsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
                         </ContextMenu>
                     </editor:TextEditor.ContextMenu>
 				</editor:TextEditor>
@@ -67,9 +65,7 @@
 					</Interaction.Behaviors>
                     <editor:TextEditor.ContextMenu>
                         <ContextMenu IsEnabled="{Binding HasUnsavedNotams, DataType=vm:AtisStationViewModel}">
-                            <MenuItem Header="Apply Without Saving" ToolTip.Tip="Temporarily apply changes to the ATIS without saving them to the profile" Command="{Binding ApplyNotamsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:False}"/>
-                            <Separator/>
-                            <MenuItem Header="Save and Apply" ToolTip.Tip="Save changes to the profile and apply them to the ATIS" Command="{Binding ApplyNotamsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
+                            <MenuItem Header="Save NOTAMs" ToolTip.Tip="Save the NOTAMs to the ATIS profile." Command="{Binding ApplyNotamsCommand, DataType=vm:AtisStationViewModel}" CommandParameter="{x:True}"/>
                         </ContextMenu>
                     </editor:TextEditor.ContextMenu>
 				</editor:TextEditor>

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -223,7 +223,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 // Apply but don't save to profile
                 ApplyAirportConditionsCommand.Execute(false).Subscribe();
-            }).DisposeWith(_disposables);
+            }, ex => Log.Error(ex, "Error applying airport conditions"))
+            .DisposeWith(_disposables);
 
         this.WhenAnyValue(x => x.NotamsTextDocument!.Text)
             .Throttle(TimeSpan.FromSeconds(5))
@@ -232,7 +233,8 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 // Apply but don't save to profile
                 ApplyNotamsCommand.Execute(false).Subscribe();
-            }).DisposeWith(_disposables);
+            }, ex => Log.Error(ex, "Error applying NOTAMs"))
+            .DisposeWith(_disposables);
 
         _websocketService.GetAtisReceived += OnGetAtisReceived;
         _websocketService.AcknowledgeAtisUpdateReceived += OnAcknowledgeAtisUpdateReceived;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -216,6 +216,24 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                 (metar, voiceRecord, networkStatus) => !string.IsNullOrEmpty(metar) && voiceRecord &&
                                                        networkStatus == NetworkConnectionStatus.Connected));
 
+        this.WhenAnyValue(x => x.AirportConditionsTextDocument!.Text)
+            .Throttle(TimeSpan.FromSeconds(5))
+            .DistinctUntilChanged()
+            .ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
+            {
+                // Apply but don't save to profile
+                ApplyAirportConditionsCommand.Execute(false).Subscribe();
+            });
+
+        this.WhenAnyValue(x => x.NotamsTextDocument!.Text)
+            .Throttle(TimeSpan.FromSeconds(5))
+            .DistinctUntilChanged()
+            .ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
+            {
+                // Apply but don't save to profile
+                ApplyNotamsCommand.Execute(false).Subscribe();
+            });
+
         _websocketService.GetAtisReceived += OnGetAtisReceived;
         _websocketService.AcknowledgeAtisUpdateReceived += OnAcknowledgeAtisUpdateReceived;
         _websocketService.ConfigureAtisReceived += OnConfigureAtisReceived;

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -223,7 +223,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 // Apply but don't save to profile
                 ApplyAirportConditionsCommand.Execute(false).Subscribe();
-            });
+            }).DisposeWith(_disposables);
 
         this.WhenAnyValue(x => x.NotamsTextDocument!.Text)
             .Throttle(TimeSpan.FromSeconds(5))
@@ -232,7 +232,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 // Apply but don't save to profile
                 ApplyNotamsCommand.Execute(false).Subscribe();
-            });
+            }).DisposeWith(_disposables);
 
         _websocketService.GetAtisReceived += OnGetAtisReceived;
         _websocketService.AcknowledgeAtisUpdateReceived += OnAcknowledgeAtisUpdateReceived;


### PR DESCRIPTION
Automatically update the ATIS with changes to the airport conditions and NOTAMs free-text. Update context menu to only have the option to save the changes to the ATIS profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Changes to airport conditions and NOTAMs are now automatically applied after a short delay when editing, without needing to manually apply them.

- **Refactor**
  - Context menus for airport conditions and NOTAMs editors have been simplified, now offering only a single option to save and apply changes. Temporary apply functionality has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->