### PR TITLE
Skip first value during initialization

### DIFF
--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -219,6 +219,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         this.WhenAnyValue(x => x.AirportConditionsTextDocument!.Text)
             .Throttle(TimeSpan.FromSeconds(5))
             .DistinctUntilChanged()
+            .Skip(1)
             .ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
             {
                 // Apply but don't save to profile
@@ -229,6 +230,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         this.WhenAnyValue(x => x.NotamsTextDocument!.Text)
             .Throttle(TimeSpan.FromSeconds(5))
             .DistinctUntilChanged()
+            .Skip(1)
             .ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
             {
                 // Apply but don't save to profile


### PR DESCRIPTION
Skip first value during initialization to prevent false invocation of "unsaved changes" dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved responsiveness by ensuring that airport conditions and NOTAMs updates are only applied after the initial load, preventing unintended actions on first load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->