### PR TITLE
Add formatting option to speak wind speed in group format

### DIFF
--- a/vATIS.Desktop/Atis/Extensions/NumberFormatExtensions.cs
+++ b/vATIS.Desktop/Atis/Extensions/NumberFormatExtensions.cs
@@ -16,6 +16,25 @@ namespace Vatsim.Vatis.Atis.Extensions;
 public static class NumberFormatExtensions
 {
     /// <summary>
+    /// Converts a numeric value to a formatted string representation, either in group format or serial format.
+    /// </summary>
+    /// <param name="value">The value to format. Must implement <see cref="IConvertible"/>.</param>
+    /// <param name="speakInGroupFormat">
+    /// If <c>true</c>, formats the value using the group format (e.g., digit-by-digit with spacing).
+    /// If <c>false</c>, uses the serial format.
+    /// </param>
+    /// <param name="speakLeadingZero">
+    /// Optional. If <c>true</c>, includes a leading zero when using the serial format.
+    /// This parameter is ignored when <paramref name="speakInGroupFormat"/> is <c>true</c>.
+    /// </param>
+    /// <returns>A formatted string representation of the value.</returns>
+    public static string ToFormat(this IConvertible value, bool speakInGroupFormat,
+        bool speakLeadingZero = false)
+    {
+        return speakInGroupFormat ? ToGroupForm(value) : ToSerialFormat(value, speakLeadingZero);
+    }
+
+    /// <summary>
     /// Converts the value into a group form.
     /// </summary>
     /// <param name="value">The number to convert.</param>

--- a/vATIS.Desktop/Atis/Nodes/SurfaceWindNode.cs
+++ b/vATIS.Desktop/Atis/Nodes/SurfaceWindNode.cs
@@ -31,7 +31,9 @@ public class SurfaceWindNode : BaseNode<SurfaceWind>
         if (format == null)
             return "";
 
-        var magVarDeg = Station.AtisFormat.SurfaceWind.MagneticVariation?.MagneticDegrees ?? null;
+        var magVarDeg = Station.AtisFormat.SurfaceWind.MagneticVariation.MagneticDegrees;
+
+        var speakLeadingZero = Station.AtisFormat.SurfaceWind.SpeakLeadingZero;
         var leadingZero = Station.AtisFormat.SurfaceWind.SpeakLeadingZero ? "00" : "";
 
         var meanDirection = node.MeanDirection?.ActualValue ?? null;
@@ -75,18 +77,35 @@ public class SurfaceWindNode : BaseNode<SurfaceWind>
             speedVariationMps = SurfaceWind.ToMps(node.SpeedVariations).ToInt32(CultureInfo.InvariantCulture);
         }
 
-        var magVarEnabled = Station.AtisFormat.SurfaceWind.MagneticVariation?.Enabled ?? false;
+        var speakInGroupForm = Station.AtisFormat.SurfaceWind.SpeakWindSpeedGroupFormat;
+        var magVarEnabled = Station.AtisFormat.SurfaceWind.MagneticVariation.Enabled;
         var meanDirectionMag = (meanDirection ?? 0).ApplyMagVar(magVarEnabled, magVarDeg).ToString("000");
 
         format = Regex.Replace(format, "{wind_dir}", meanDirectionMag.ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, "{wind_spd}", meanSpeed?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{wind_spd\|kt}", meanSpeedKts?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{wind_spd\|mps}", meanSpeedMps?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, "{wind_gust}", speedVariations?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{wind_gust\|kt}", speedVariationKts?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, @"{wind_gust\|mps}", speedVariationMps?.ToString(leadingZero).ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, "{wind_vmin}", minDirectionVariation?.ApplyMagVar(magVarEnabled, magVarDeg).ToString("000").ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
-        format = Regex.Replace(format, "{wind_vmax}", maxDirectionVariation?.ApplyMagVar(magVarEnabled, magVarDeg).ToString("000").ToSerialFormat() ?? "", RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{wind_spd}",
+            meanSpeed?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{wind_spd\|kt}",
+            meanSpeedKts?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{wind_spd\|mps}",
+            meanSpeedMps?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{wind_gust}",
+            speedVariations?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{wind_gust\|kt}",
+            speedVariationKts?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, @"{wind_gust\|mps}",
+            speedVariationMps?.ToString(leadingZero).ToFormat(speakInGroupForm, speakLeadingZero) ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{wind_vmin}",
+            minDirectionVariation?.ApplyMagVar(magVarEnabled, magVarDeg).ToString("000").ToSerialFormat() ?? "",
+            RegexOptions.IgnoreCase);
+        format = Regex.Replace(format, "{wind_vmax}",
+            maxDirectionVariation?.ApplyMagVar(magVarEnabled, magVarDeg).ToString("000").ToSerialFormat() ?? "",
+            RegexOptions.IgnoreCase);
         format = Regex.Replace(format, "{wind_unit}", GetSpokenWindUnit(node.MeanSpeed), RegexOptions.IgnoreCase);
 
         return format;
@@ -100,8 +119,7 @@ public class SurfaceWindNode : BaseNode<SurfaceWind>
         if (format == null)
             return "";
 
-        var magVarDeg = Station.AtisFormat.SurfaceWind.MagneticVariation?.MagneticDegrees ?? null;
-
+        var magVarDeg = Station.AtisFormat.SurfaceWind.MagneticVariation.MagneticDegrees;
         var meanDirection = node.MeanDirection?.ActualValue ?? null;
         var meanSpeed = node.MeanSpeed?.ActualValue ?? null;
         var speedVariations = node.SpeedVariations?.ActualValue ?? null;
@@ -143,7 +161,7 @@ public class SurfaceWindNode : BaseNode<SurfaceWind>
             speedVariationMps = SurfaceWind.ToMps(node.SpeedVariations).ToInt32(CultureInfo.InvariantCulture);
         }
 
-        var magVarEnabled = Station.AtisFormat.SurfaceWind.MagneticVariation?.Enabled ?? false;
+        var magVarEnabled = Station.AtisFormat.SurfaceWind.MagneticVariation.Enabled;
         var meanDirectionMag = (meanDirection ?? 0).ApplyMagVar(magVarEnabled, magVarDeg).ToString("000");
 
         format = Regex.Replace(format, "{wind_dir}", meanDirectionMag, RegexOptions.IgnoreCase);

--- a/vATIS.Desktop/Profiles/AtisFormat/Nodes/SurfaceWind.cs
+++ b/vATIS.Desktop/Profiles/AtisFormat/Nodes/SurfaceWind.cs
@@ -18,6 +18,11 @@ public class SurfaceWind
     public bool SpeakLeadingZero { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to speak the wind speed in group format.
+    /// </summary>
+    public bool SpeakWindSpeedGroupFormat { get; set; }
+
+    /// <summary>
     /// Gets or sets the magnetic variation metadata.
     /// </summary>
     public MagneticVariationMeta MagneticVariation { get; set; } = new();

--- a/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/FormattingView.axaml
@@ -94,7 +94,8 @@
 			<!--Wind-->
 			<StackPanel Spacing="10" Margin="10,0,10,0" IsVisible="{Binding SelectedFormattingOption, DataType=vm:FormattingViewModel, Converter={StaticResource StringToBoolConverter}, ConverterParameter='Wind'}">
 				<StackPanel Orientation="Horizontal" Spacing="10" Margin="0,0,0,5">
-					<CheckBox IsChecked="{Binding SpeakWindSpeedLeadingZero, DataType=vm:FormattingViewModel}" Theme="{StaticResource CheckBox}">Speak wind speed leading zero</CheckBox>
+                    <CheckBox x:Name="SpeakWindSpeedGroupFormat" IsChecked="{Binding SpeakWindSpeedGroupFormat, DataType=vm:FormattingViewModel}" Theme="{StaticResource CheckBox}">Speak wind speed in group format</CheckBox>
+                    <CheckBox IsEnabled="{Binding !#SpeakWindSpeedGroupFormat.IsChecked}" IsChecked="{Binding SpeakWindSpeedLeadingZero, DataType=vm:FormattingViewModel}" Theme="{StaticResource CheckBox}">Speak wind speed leading zero</CheckBox>
 					<StackPanel Orientation="Horizontal" Spacing="10">
 						<CheckBox IsChecked="{Binding MagneticVariationEnabled, DataType=vm:FormattingViewModel}" Theme="{StaticResource CheckBox}" Name="MagneticVariation">Magnetic Variation</CheckBox>
 						<TextBox Text="{Binding MagneticVariationValue, DataType=vm:FormattingViewModel}" MaxLength="3" MinWidth="60" IsEnabled="{Binding #MagneticVariation.IsChecked}" Theme="{StaticResource DarkTextBox}">

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/FormattingViewModel.cs
@@ -47,6 +47,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
     private string? _observationTimeTextTemplate;
     private string? _observationTimeVoiceTemplate;
     private bool _speakWindSpeedLeadingZero;
+    private bool _speakWindSpeedGroupFormat;
     private bool _magneticVariationEnabled;
     private string? _magneticVariationValue;
     private string? _standardWindTextTemplate;
@@ -287,6 +288,19 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         {
             this.RaiseAndSetIfChanged(ref _speakWindSpeedLeadingZero, value);
             _changeTracker.TrackChange(nameof(SpeakWindSpeedLeadingZero), value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to speak wind speed in group format.
+    /// </summary>
+    public bool SpeakWindSpeedGroupFormat
+    {
+        get => _speakWindSpeedGroupFormat;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _speakWindSpeedGroupFormat, value);
+            _changeTracker.TrackChange(nameof(SpeakWindSpeedGroupFormat), value);
         }
     }
 
@@ -1464,6 +1478,11 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
             SelectedStation.AtisFormat.SurfaceWind.SpeakLeadingZero = SpeakWindSpeedLeadingZero;
         }
 
+        if (SelectedStation.AtisFormat.SurfaceWind.SpeakWindSpeedGroupFormat != SpeakWindSpeedGroupFormat)
+        {
+            SelectedStation.AtisFormat.SurfaceWind.SpeakWindSpeedGroupFormat = SpeakWindSpeedGroupFormat;
+        }
+
         if (SelectedStation.AtisFormat.SurfaceWind.MagneticVariation.Enabled != MagneticVariationEnabled)
         {
             SelectedStation.AtisFormat.SurfaceWind.MagneticVariation.Enabled = MagneticVariationEnabled;
@@ -1973,6 +1992,7 @@ public class FormattingViewModel : ReactiveViewModelBase, IDisposable
         FormattingOptions = [.. items];
 
         SpeakWindSpeedLeadingZero = station.AtisFormat.SurfaceWind.SpeakLeadingZero;
+        SpeakWindSpeedGroupFormat = station.AtisFormat.SurfaceWind.SpeakWindSpeedGroupFormat;
         MagneticVariationEnabled = station.AtisFormat.SurfaceWind.MagneticVariation.Enabled;
         MagneticVariationValue = station.AtisFormat.SurfaceWind.MagneticVariation.MagneticDegrees.ToString();
         RoutineObservationTime = string.Join(",", station.AtisFormat.ObservationTime.StandardUpdateTime ?? []);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to speak wind speed in group format within the configuration interface.
  - Introduced a new checkbox for "Speak wind speed in group format" in the wind configuration section.
  - The "Speak wind speed leading zero" option is now disabled when group format is selected, ensuring mutually exclusive selection.

- **Improvements**
  - Enhanced wind speed formatting in voice output to support both group and serial formats based on user selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->