### PR TITLE
Refactor RVR parsing

### DIFF
--- a/vATIS.Desktop/Weather/Decoder/Entity/RunwayVisualRange.cs
+++ b/vATIS.Desktop/Weather/Decoder/Entity/RunwayVisualRange.cs
@@ -44,6 +44,26 @@ public sealed class RunwayVisualRange
     public string? Runway { get; set; }
 
     /// <summary>
+    /// Gets or sets the runway identifier suffix (L/R/C).
+    /// </summary>
+    public string? RunwaySuffix { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the RVR is reported as missing (////).
+    /// </summary>
+    public bool IsMissing { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the reported value is "less than" (e.g., M0600).
+    /// </summary>
+    public bool IsLessThan { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the reported value is "greater than" (e.g., P1500).
+    /// </summary>
+    public bool IsGreaterThan { get; set; }
+
+    /// <summary>
     /// Gets or sets the visual range value associated with the runway.
     /// </summary>
     public Value? VisualRange { get; set; }


### PR DESCRIPTION
Refactor RVR parser and correctly match RVR with missing values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying runway suffixes (such as L, R, or C) and new indicators for "less than", "greater than", and missing runway visual range (RVR) values in weather reports.

- **Refactor**
  - Improved the accuracy and clarity of RVR parsing and reporting, resulting in more precise runway visual range information for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->