### PR TITLE
Keep context menu open when menuitem is clicked

### DIFF
--- a/vATIS.Desktop/Ui/Styles/MiniWindowMenu.axaml
+++ b/vATIS.Desktop/Ui/Styles/MiniWindowMenu.axaml
@@ -108,6 +108,7 @@
 
     <ControlTheme x:Key="MiniWindow_MenuItem" TargetType="MenuItem">
         <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="StaysOpenOnClick" Value="True"/>
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Menu items in the mini window now remain open after being clicked, allowing for multiple selections without closing the menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->