### PR TITLE
feat: Integrate native D-ATIS auto-loading

### DIFF
--- a/vATIS.Desktop/Atis/DatisRepository.cs
+++ b/vATIS.Desktop/Atis/DatisRepository.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using Serilog;
@@ -28,6 +29,7 @@ public sealed class DatisRepository : IDatisRepository, IDisposable
     private readonly string? _digitalAtisApiUrl;
     private readonly DispatcherTimer _updateTimer = new() { Interval = TimeSpan.FromSeconds(UpdateIntervalSeconds) };
     private readonly Dictionary<string, AtisStation> _monitoredStations = [];
+    private int _isUpdating;
     private bool _isDisposed;
 
     /// <summary>
@@ -45,7 +47,22 @@ public sealed class DatisRepository : IDatisRepository, IDisposable
         _textProcessor = textProcessor;
         _digitalAtisApiUrl = appConfigurationProvider.DigitalAtisApiUrl;
 
-        _updateTimer.Tick += async (_, _) => { await UpdateAsync(); };
+        _updateTimer.Tick += async (_, _) =>
+        {
+            if (Interlocked.Exchange(ref _isUpdating, 1) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                await UpdateAsync();
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _isUpdating, 0);
+            }
+        };
         _updateTimer.Start();
     }
 
@@ -147,6 +164,7 @@ public sealed class DatisRepository : IDatisRepository, IDisposable
         catch (Exception ex)
         {
             Log.Error(ex, "Error fetching D-ATIS for {Station}", station.Identifier);
+            PublishNotAvailable(station);
         }
     }
 }

--- a/vATIS.Desktop/Atis/DatisRepository.cs
+++ b/vATIS.Desktop/Atis/DatisRepository.cs
@@ -1,0 +1,152 @@
+// <copyright file="DatisRepository.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using Serilog;
+using Vatsim.Vatis.Config;
+using Vatsim.Vatis.Events;
+using Vatsim.Vatis.Events.EventBus;
+using Vatsim.Vatis.Io;
+using Vatsim.Vatis.Networking.AtisHub.Dto;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Atis;
+
+/// <inheritdoc cref="IDatisRepository"/>
+public sealed class DatisRepository : IDatisRepository, IDisposable
+{
+    private const int UpdateIntervalSeconds = 300;
+    private readonly IDownloader _downloader;
+    private readonly IDatisTextProcessor _textProcessor;
+    private readonly string? _digitalAtisApiUrl;
+    private readonly DispatcherTimer _updateTimer = new() { Interval = TimeSpan.FromSeconds(UpdateIntervalSeconds) };
+    private readonly Dictionary<string, AtisStation> _monitoredStations = [];
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatisRepository"/> class.
+    /// </summary>
+    /// <param name="downloader">The downloader used to retrieve D-ATIS data.</param>
+    /// <param name="appConfigurationProvider">The application configuration provider.</param>
+    /// <param name="textProcessor">The text processor for D-ATIS bodies.</param>
+    public DatisRepository(
+        IDownloader downloader,
+        IAppConfigurationProvider appConfigurationProvider,
+        IDatisTextProcessor textProcessor)
+    {
+        _downloader = downloader;
+        _textProcessor = textProcessor;
+        _digitalAtisApiUrl = appConfigurationProvider.DigitalAtisApiUrl;
+
+        _updateTimer.Tick += async (_, _) => { await UpdateAsync(); };
+        _updateTimer.Start();
+    }
+
+    /// <inheritdoc />
+    public void MonitorStation(AtisStation station)
+    {
+        _monitoredStations[station.Id] = station;
+        FetchForStationAsync(station).ContinueWith(
+            t => Log.Error(t.Exception, "Error during initial D-ATIS fetch for {StationId}", station.Identifier),
+            TaskContinuationOptions.OnlyOnFaulted);
+    }
+
+    /// <inheritdoc />
+    public void RemoveStation(string stationId)
+    {
+        _monitoredStations.Remove(stationId);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!_isDisposed)
+        {
+            _updateTimer.Stop();
+            _isDisposed = true;
+        }
+    }
+
+    private static DigitalAtisResponseDto? FindMatchingAtis(List<DigitalAtisResponseDto> datisList, AtisType atisType)
+    {
+        return atisType switch
+        {
+            AtisType.Combined => datisList.FirstOrDefault(a => a.AtisType == "combined")
+                                 ?? datisList.FirstOrDefault(a => a.AtisType == "dep"),
+            AtisType.Arrival => datisList.FirstOrDefault(a => a.AtisType == "arr"),
+            AtisType.Departure => datisList.FirstOrDefault(a => a.AtisType == "dep"),
+            _ => null,
+        };
+    }
+
+    private static void PublishNotAvailable(AtisStation station)
+    {
+        EventBus.Instance.Publish(new DatisReceived(
+            new DatisResult(station.Id, "D-ATIS NOT AVBL.", string.Empty, null)));
+    }
+
+    private async Task UpdateAsync()
+    {
+        foreach (var station in _monitoredStations.Values.ToList())
+        {
+            await FetchForStationAsync(station);
+        }
+    }
+
+    private async Task FetchForStationAsync(AtisStation station)
+    {
+        try
+        {
+            var url = $"{_digitalAtisApiUrl}/{station.Identifier}";
+            Log.Information("Fetching D-ATIS for {Station} from {Url}", station.Identifier, url);
+
+            var response = await _downloader.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Warning("D-ATIS request failed for {Station}: {StatusCode}", station.Identifier, response.StatusCode);
+                PublishNotAvailable(station);
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var datisList = JsonSerializer.Deserialize(json, SourceGenerationContext.NewDefault.ListDigitalAtisResponseDto);
+
+            if (datisList == null || datisList.Count == 0)
+            {
+                Log.Information("No D-ATIS data available for {Station}", station.Identifier);
+                PublishNotAvailable(station);
+                return;
+            }
+
+            var match = FindMatchingAtis(datisList, station.AtisType);
+            if (match == null || string.IsNullOrWhiteSpace(match.Body))
+            {
+                Log.Information("No matching D-ATIS entry for {Station} ({AtisType})", station.Identifier, station.AtisType);
+                PublishNotAvailable(station);
+                return;
+            }
+
+            char? atisLetter = char.TryParse(match.AtisLetter, out var letter) ? letter : null;
+
+            var result = _textProcessor.Process(
+                match.Body,
+                station.Id,
+                atisLetter,
+                station.Contractions,
+                station.DatisTextReplacements);
+
+            EventBus.Instance.Publish(new DatisReceived(result));
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error fetching D-ATIS for {Station}", station.Identifier);
+        }
+    }
+}

--- a/vATIS.Desktop/Atis/DatisRepository.cs
+++ b/vATIS.Desktop/Atis/DatisRepository.cs
@@ -157,7 +157,11 @@ public sealed class DatisRepository : IDatisRepository, IDisposable
                 station.Id,
                 atisLetter,
                 station.Contractions,
-                station.DatisTextReplacements);
+                station.DatisTextReplacements,
+                station.DatisPrependAirportConditions,
+                station.DatisAppendAirportConditions,
+                station.DatisPrependNotams,
+                station.DatisAppendNotams);
 
             EventBus.Instance.Publish(new DatisReceived(result));
         }

--- a/vATIS.Desktop/Atis/DatisResult.cs
+++ b/vATIS.Desktop/Atis/DatisResult.cs
@@ -1,0 +1,15 @@
+// <copyright file="DatisResult.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Atis;
+
+/// <summary>
+/// Represents the processed result of a D-ATIS fetch for a station.
+/// </summary>
+/// <param name="StationId">The unique identifier of the ATIS station.</param>
+/// <param name="AirportConditions">The processed airport conditions text.</param>
+/// <param name="Notams">The processed NOTAMs text.</param>
+/// <param name="AtisLetter">The current ATIS letter, if available.</param>
+public record DatisResult(string StationId, string AirportConditions, string Notams, char? AtisLetter);

--- a/vATIS.Desktop/Atis/DatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/DatisTextProcessor.cs
@@ -112,6 +112,10 @@ public sealed class DatisTextProcessor : IDatisTextProcessor
             {
                 Log.Warning(ex, "Invalid D-ATIS replacement regex pattern: {Pattern}", replacement.Pattern);
             }
+            catch (ArgumentException ex)
+            {
+                Log.Warning(ex, "Invalid D-ATIS replacement value for regex pattern: {Pattern}", replacement.Pattern);
+            }
             catch (RegexMatchTimeoutException ex)
             {
                 Log.Warning(ex, "Timed out applying D-ATIS replacement regex pattern: {Pattern}", replacement.Pattern);

--- a/vATIS.Desktop/Atis/DatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/DatisTextProcessor.cs
@@ -1,0 +1,178 @@
+// <copyright file="DatisTextProcessor.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Serilog;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Atis;
+
+/// <inheritdoc cref="IDatisTextProcessor"/>
+public sealed class DatisTextProcessor : IDatisTextProcessor
+{
+    private const string NotamDelimiter = "NOTAMS... ";
+
+    /// <inheritdoc />
+    public DatisResult Process(
+        string rawBody,
+        string stationId,
+        char? atisLetter,
+        List<ContractionMeta> contractions,
+        List<DatisTextReplacement> replacements)
+    {
+        var text = StripEnvelope(rawBody);
+        text = NormalizeNotamDelimiters(text);
+        text = ApplyReplacements(text, replacements);
+        text = NormalizeWhitespace(text);
+        text = CleanPunctuation(text);
+        text = ExpandContractions(text, contractions);
+
+        var (airportConditions, notams) = SplitConditionsAndNotams(text);
+
+        return new DatisResult(stationId, airportConditions, notams, atisLetter);
+    }
+
+    /// <summary>
+    /// Removes the first two sentences (identification envelope) and trailing
+    /// "ADVS YOU HAVE..." text from the D-ATIS body.
+    /// </summary>
+    private static string StripEnvelope(string text)
+    {
+        // Remove first 2 sentences (e.g. "KJFK ATIS INFO A. 0153Z." or similar)
+        var sentences = text.Split(". ", 3, StringSplitOptions.None);
+        if (sentences.Length > 2)
+        {
+            text = sentences[2];
+        }
+
+        // Remove trailing "ADVS YOU HAVE..." onward
+        text = Regex.Replace(text, @" \.{0,3}ADVS YOU HAVE.*", string.Empty);
+
+        return text;
+    }
+
+    /// <summary>
+    /// Normalizes various NOTAM header variants into a single delimiter.
+    /// </summary>
+    private static string NormalizeNotamDelimiters(string text)
+    {
+        text = text.Replace("NOTICE TO AIR MISSIONS, NOTAMS. ", NotamDelimiter);
+        text = text.Replace("NOTICE TO AIR MISSIONS. ", NotamDelimiter);
+        text = text.Replace("NOTICE TO AIR MEN. ", NotamDelimiter);
+        text = text.Replace("NOTICE TO AIRMEN. ", NotamDelimiter);
+        text = text.Replace("NOTAMS. ", NotamDelimiter);
+        text = text.Replace("NOTAM. ", NotamDelimiter);
+        return text;
+    }
+
+    /// <summary>
+    /// Applies user-defined replacement rules. For regex patterns, also strips an optional
+    /// trailing punctuation character after the match.
+    /// </summary>
+    private static string ApplyReplacements(string text, List<DatisTextReplacement> replacements)
+    {
+        foreach (var replacement in replacements)
+        {
+            if (string.IsNullOrEmpty(replacement.Pattern))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (replacement.IsRegex)
+                {
+                    text = Regex.Replace(text, replacement.Pattern + @"[,.;]{0,1}", replacement.Replacement);
+                }
+                else
+                {
+                    text = text.Replace(replacement.Pattern, replacement.Replacement);
+                }
+            }
+            catch (RegexParseException ex)
+            {
+                Log.Warning(ex, "Invalid D-ATIS replacement regex pattern: {Pattern}", replacement.Pattern);
+            }
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Collapses multiple consecutive whitespace characters into a single space and trims.
+    /// </summary>
+    private static string NormalizeWhitespace(string text)
+    {
+        return Regex.Replace(text, @"\s+", " ").Trim();
+    }
+
+    /// <summary>
+    /// Fixes double periods, spacing around punctuation, and other punctuation artifacts.
+    /// </summary>
+    private static string CleanPunctuation(string text)
+    {
+        // Preserve triple dots by temporarily replacing them
+        text = text.Replace("...", "/./");
+        text = text.Replace("..", ".");
+        text = text.Replace("/./", "...");
+
+        text = text.Replace("  ", " ");
+        text = text.Replace(" . ", ". ");
+        text = text.Replace(", ,", ",");
+        text = text.Replace(" ; ", "; ");
+        text = text.Replace(" .,", " ,");
+        text = text.Replace(" , ", ", ");
+        text = text.Replace("., ", ", ");
+        text = text.Replace("&amp;", "&");
+        text = text.Replace(" ;.", ".");
+        text = text.Replace(" ;,", ",");
+
+        return text;
+    }
+
+    /// <summary>
+    /// Replaces contraction text with template variable references (e.g. <c>@VariableName</c>)
+    /// so that the vATIS template engine expands them. Contractions are sorted by text length
+    /// descending to avoid partial matches. Digit-only contractions are skipped.
+    /// </summary>
+    private static string ExpandContractions(string text, List<ContractionMeta> contractions)
+    {
+        var sorted = contractions
+            .Where(c => !string.IsNullOrEmpty(c.Text) && !string.IsNullOrEmpty(c.VariableName))
+            .Where(c => !c.Text!.All(char.IsDigit))
+            .OrderByDescending(c => c.Text!.Length)
+            .ToList();
+
+        foreach (var contraction in sorted)
+        {
+            var pattern = @"(?<!@)\b" + Regex.Escape(contraction.Text!) + @"\b";
+            var variable = "@" + contraction.VariableName;
+
+            // Replace at word boundaries followed by common punctuation or space
+            text = Regex.Replace(text, pattern + @"(?=[,.\s;]|$)", variable);
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Splits text on the NOTAM delimiter into airport conditions and NOTAMs sections.
+    /// </summary>
+    private static (string AirportConditions, string Notams) SplitConditionsAndNotams(string text)
+    {
+        var delimiterIndex = text.IndexOf(NotamDelimiter, StringComparison.Ordinal);
+        if (delimiterIndex >= 0)
+        {
+            var conditions = text[..delimiterIndex].Trim();
+            var notams = text[(delimiterIndex + NotamDelimiter.Length)..].Trim();
+            return (conditions, notams);
+        }
+
+        return (text.Trim(), string.Empty);
+    }
+}

--- a/vATIS.Desktop/Atis/DatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/DatisTextProcessor.cs
@@ -23,16 +23,25 @@ public sealed class DatisTextProcessor : IDatisTextProcessor
         string stationId,
         char? atisLetter,
         List<ContractionMeta> contractions,
-        List<DatisTextReplacement> replacements)
+        List<DatisTextReplacement> replacements,
+        string prependAirportConditions,
+        string appendAirportConditions,
+        string prependNotams,
+        string appendNotams)
     {
         var text = StripEnvelope(rawBody);
         text = NormalizeNotamDelimiters(text);
         text = ApplyReplacements(text, replacements);
         text = NormalizeWhitespace(text);
         text = CleanPunctuation(text);
-        text = ExpandContractions(text, contractions);
 
         var (airportConditions, notams) = SplitConditionsAndNotams(text);
+
+        airportConditions = ApplyPrependAppend(airportConditions, prependAirportConditions, appendAirportConditions);
+        notams = ApplyPrependAppend(notams, prependNotams, appendNotams);
+
+        airportConditions = ExpandContractions(airportConditions, contractions);
+        notams = ExpandContractions(notams, contractions);
 
         return new DatisResult(stationId, airportConditions, notams, atisLetter);
     }
@@ -167,6 +176,24 @@ public sealed class DatisTextProcessor : IDatisTextProcessor
         }
 
         return text;
+    }
+
+    /// <summary>
+    /// Prepends and/or appends user-defined text to a section, separated by spaces.
+    /// </summary>
+    private static string ApplyPrependAppend(string text, string prepend, string append)
+    {
+        if (!string.IsNullOrWhiteSpace(prepend))
+        {
+            text = prepend.Trim() + " " + text;
+        }
+
+        if (!string.IsNullOrWhiteSpace(append))
+        {
+            text = text + " " + append.Trim();
+        }
+
+        return text.Trim();
     }
 
     /// <summary>

--- a/vATIS.Desktop/Atis/DatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/DatisTextProcessor.cs
@@ -87,7 +87,12 @@ public sealed class DatisTextProcessor : IDatisTextProcessor
             {
                 if (replacement.IsRegex)
                 {
-                    text = Regex.Replace(text, replacement.Pattern + @"[,.;]{0,1}", replacement.Replacement);
+                    text = Regex.Replace(
+                        text,
+                        replacement.Pattern + @"[,.;]{0,1}",
+                        replacement.Replacement,
+                        RegexOptions.None,
+                        TimeSpan.FromSeconds(1));
                 }
                 else
                 {
@@ -97,6 +102,10 @@ public sealed class DatisTextProcessor : IDatisTextProcessor
             catch (RegexParseException ex)
             {
                 Log.Warning(ex, "Invalid D-ATIS replacement regex pattern: {Pattern}", replacement.Pattern);
+            }
+            catch (RegexMatchTimeoutException ex)
+            {
+                Log.Warning(ex, "Timed out applying D-ATIS replacement regex pattern: {Pattern}", replacement.Pattern);
             }
         }
 

--- a/vATIS.Desktop/Atis/IDatisRepository.cs
+++ b/vATIS.Desktop/Atis/IDatisRepository.cs
@@ -1,0 +1,26 @@
+// <copyright file="IDatisRepository.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Atis;
+
+/// <summary>
+/// Manages periodic fetching of D-ATIS data for monitored stations.
+/// </summary>
+public interface IDatisRepository
+{
+    /// <summary>
+    /// Begins monitoring a station for D-ATIS data, fetching immediately and then on each timer tick.
+    /// </summary>
+    /// <param name="station">The ATIS station to monitor.</param>
+    void MonitorStation(AtisStation station);
+
+    /// <summary>
+    /// Stops monitoring a station for D-ATIS data.
+    /// </summary>
+    /// <param name="stationId">The unique identifier of the station to remove.</param>
+    void RemoveStation(string stationId);
+}

--- a/vATIS.Desktop/Atis/IDatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/IDatisTextProcessor.cs
@@ -21,11 +21,19 @@ public interface IDatisTextProcessor
     /// <param name="atisLetter">The current ATIS letter from the API response, if available.</param>
     /// <param name="contractions">The contraction definitions configured for the station.</param>
     /// <param name="replacements">The text replacement rules configured for the station.</param>
+    /// <param name="prependAirportConditions">Text to prepend to airport conditions after processing.</param>
+    /// <param name="appendAirportConditions">Text to append to airport conditions after processing.</param>
+    /// <param name="prependNotams">Text to prepend to NOTAMs after processing.</param>
+    /// <param name="appendNotams">Text to append to NOTAMs after processing.</param>
     /// <returns>A <see cref="DatisResult"/> with processed airport conditions and NOTAMs.</returns>
     DatisResult Process(
         string rawBody,
         string stationId,
         char? atisLetter,
         List<ContractionMeta> contractions,
-        List<DatisTextReplacement> replacements);
+        List<DatisTextReplacement> replacements,
+        string prependAirportConditions,
+        string appendAirportConditions,
+        string prependNotams,
+        string appendNotams);
 }

--- a/vATIS.Desktop/Atis/IDatisTextProcessor.cs
+++ b/vATIS.Desktop/Atis/IDatisTextProcessor.cs
@@ -1,0 +1,31 @@
+// <copyright file="IDatisTextProcessor.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Atis;
+
+/// <summary>
+/// Processes raw D-ATIS text into structured airport conditions and NOTAMs.
+/// </summary>
+public interface IDatisTextProcessor
+{
+    /// <summary>
+    /// Processes a raw D-ATIS body into a <see cref="DatisResult"/> containing separated airport conditions and NOTAMs.
+    /// </summary>
+    /// <param name="rawBody">The raw D-ATIS text body.</param>
+    /// <param name="stationId">The unique identifier of the ATIS station.</param>
+    /// <param name="atisLetter">The current ATIS letter from the API response, if available.</param>
+    /// <param name="contractions">The contraction definitions configured for the station.</param>
+    /// <param name="replacements">The text replacement rules configured for the station.</param>
+    /// <returns>A <see cref="DatisResult"/> with processed airport conditions and NOTAMs.</returns>
+    DatisResult Process(
+        string rawBody,
+        string stationId,
+        char? atisLetter,
+        List<ContractionMeta> contractions,
+        List<DatisTextReplacement> replacements);
+}

--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -114,8 +114,8 @@ public class AppConfig : IAppConfig
             VoiceRecordAtisDialogWindowPosition = config.VoiceRecordAtisDialogWindowPosition;
             MicrophoneDevice = config.MicrophoneDevice;
             PlaybackDevice = config.PlaybackDevice;
-            AutoFetchAtisLetter = config.AutoFetchAtisLetter;
             AutoFetchDatis = config.AutoFetchDatis;
+            AutoFetchAtisLetter = config.AutoFetchAtisLetter || AutoFetchDatis;
             SuppressReleaseNotes = config.SuppressReleaseNotes;
         }
 

--- a/vATIS.Desktop/Config/AppConfig.cs
+++ b/vATIS.Desktop/Config/AppConfig.cs
@@ -68,6 +68,9 @@ public class AppConfig : IAppConfig
     public bool AutoFetchAtisLetter { get; set; }
 
     /// <inheritdoc />
+    public bool AutoFetchDatis { get; set; }
+
+    /// <inheritdoc />
     public bool SuppressReleaseNotes { get; set; }
 
     /// <inheritdoc />
@@ -112,6 +115,7 @@ public class AppConfig : IAppConfig
             MicrophoneDevice = config.MicrophoneDevice;
             PlaybackDevice = config.PlaybackDevice;
             AutoFetchAtisLetter = config.AutoFetchAtisLetter;
+            AutoFetchDatis = config.AutoFetchDatis;
             SuppressReleaseNotes = config.SuppressReleaseNotes;
         }
 

--- a/vATIS.Desktop/Config/IAppConfig.cs
+++ b/vATIS.Desktop/Config/IAppConfig.cs
@@ -103,6 +103,11 @@ public interface IAppConfig
     bool AutoFetchAtisLetter { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to automatically fetch and populate real-world D-ATIS data.
+    /// </summary>
+    bool AutoFetchDatis { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to suppress the release notes window after updating.
     /// </summary>
     bool SuppressReleaseNotes { get; set; }

--- a/vATIS.Desktop/Container/Factory/ViewModelFactory.cs
+++ b/vATIS.Desktop/Container/Factory/ViewModelFactory.cs
@@ -126,6 +126,8 @@ internal class ViewModelFactory : IViewModelFactory
     /// <returns>A new <see cref="DatisReplacementsViewModel"/> instance.</returns>
     public DatisReplacementsViewModel CreateDatisReplacementsViewModel()
     {
-        return new DatisReplacementsViewModel(_provider.GetService<IAppConfig>());
+        return new DatisReplacementsViewModel(
+            _provider.GetService<IProfileRepository>(),
+            _provider.GetService<ISessionManager>());
     }
 }

--- a/vATIS.Desktop/Container/Factory/ViewModelFactory.cs
+++ b/vATIS.Desktop/Container/Factory/ViewModelFactory.cs
@@ -56,7 +56,8 @@ internal class ViewModelFactory : IViewModelFactory
             _provider.GetService<IAtisHubConnection>(),
             _provider.GetService<ISessionManager>(),
             _provider.GetService<IProfileRepository>(),
-            _provider.GetService<IWebsocketService>());
+            _provider.GetService<IWebsocketService>(),
+            _provider.GetService<IDatisRepository>());
     }
 
     /// <summary>
@@ -117,5 +118,14 @@ internal class ViewModelFactory : IViewModelFactory
             _provider.GetService<IMetarRepository>(),
             _provider.GetService<IProfileRepository>(),
             _provider.GetService<ISessionManager>());
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="DatisReplacementsViewModel"/> class.
+    /// </summary>
+    /// <returns>A new <see cref="DatisReplacementsViewModel"/> instance.</returns>
+    public DatisReplacementsViewModel CreateDatisReplacementsViewModel()
+    {
+        return new DatisReplacementsViewModel(_provider.GetService<IAppConfig>());
     }
 }

--- a/vATIS.Desktop/Container/ServiceProvider.cs
+++ b/vATIS.Desktop/Container/ServiceProvider.cs
@@ -50,6 +50,8 @@ namespace Vatsim.Vatis.Container;
 [Singleton(typeof(IProfileRepository), typeof(ProfileRepository))]
 [Singleton(typeof(IWebsocketService), typeof(WebsocketService))]
 [Singleton(typeof(IClientAuth), typeof(ClientAuth))]
+[Singleton(typeof(IDatisTextProcessor), typeof(DatisTextProcessor))]
+[Singleton<IDatisRepository>(Factory = nameof(CreateDatisRepository))]
 [Singleton<IMetarRepository>(Factory = nameof(CreateMetarRepository))]
 [Singleton<IAtisHubConnection>(Factory = nameof(CreateAtisHubConnection))]
 [Transient(typeof(IWindowFactory), Factory = nameof(WindowFactory))]
@@ -98,6 +100,7 @@ namespace Vatsim.Vatis.Container;
 [Transient(typeof(GeneralConfigViewModel))]
 [Transient(typeof(PresetsViewModel))]
 [Transient(typeof(SandboxViewModel))]
+[Transient(typeof(DatisReplacementsViewModel))]
 [Transient(typeof(SortAtisStationsDialogViewModel))]
 [Transient(typeof(ReleaseNotesDialogViewModel))]
 internal sealed partial class ServiceProvider
@@ -136,6 +139,14 @@ internal sealed partial class ServiceProvider
     /// </summary>
     /// <returns>A new instance of the <see cref="VoiceServerConnectionFactory"/> class.</returns>
     public IVoiceServerConnectionFactory VoiceServerConnectionFactory() => new VoiceServerConnectionFactory(this);
+
+    private IDatisRepository CreateDatisRepository()
+    {
+        return new DatisRepository(
+            GetService<IDownloader>(),
+            GetService<IAppConfigurationProvider>(),
+            GetService<IDatisTextProcessor>());
+    }
 
     private IMetarRepository CreateMetarRepository()
     {

--- a/vATIS.Desktop/Events/DatisReceived.cs
+++ b/vATIS.Desktop/Events/DatisReceived.cs
@@ -1,0 +1,14 @@
+// <copyright file="DatisReceived.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using Vatsim.Vatis.Atis;
+
+namespace Vatsim.Vatis.Events;
+
+/// <summary>
+/// Represents an event that is raised when D-ATIS data has been fetched and processed for a station.
+/// </summary>
+/// <param name="Result">The processed D-ATIS result.</param>
+public record DatisReceived(DatisResult Result) : IEvent;

--- a/vATIS.Desktop/Profiles/Models/AtisStation.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisStation.cs
@@ -128,6 +128,26 @@ public class AtisStation : ReactiveObject
     public List<DatisTextReplacement> DatisTextReplacements { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets text to prepend to D-ATIS airport conditions.
+    /// </summary>
+    public string DatisPrependAirportConditions { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets text to append to D-ATIS airport conditions.
+    /// </summary>
+    public string DatisAppendAirportConditions { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets text to prepend to D-ATIS NOTAMs.
+    /// </summary>
+    public string DatisPrependNotams { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets text to append to D-ATIS NOTAMs.
+    /// </summary>
+    public string DatisAppendNotams { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets a value indicating whether the ATIS station is an FAA ATIS station.
     /// </summary>
     [JsonIgnore]
@@ -243,6 +263,10 @@ public class AtisStation : ReactiveObject
             AirportConditionDefinitions = AirportConditionDefinitions.Select(x => x.Clone()).ToList(),
             NotamDefinitions = NotamDefinitions.Select(x => x.Clone()).ToList(),
             DatisTextReplacements = DatisTextReplacements.Select(x => x.Clone()).ToList(),
+            DatisPrependAirportConditions = DatisPrependAirportConditions,
+            DatisAppendAirportConditions = DatisAppendAirportConditions,
+            DatisPrependNotams = DatisPrependNotams,
+            DatisAppendNotams = DatisAppendNotams,
         };
     }
 

--- a/vATIS.Desktop/Profiles/Models/AtisStation.cs
+++ b/vATIS.Desktop/Profiles/Models/AtisStation.cs
@@ -123,6 +123,11 @@ public class AtisStation : ReactiveObject
     public List<StaticDefinition> NotamDefinitions { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the list of text replacement rules applied to D-ATIS data for this station.
+    /// </summary>
+    public List<DatisTextReplacement> DatisTextReplacements { get; set; } = [];
+
+    /// <summary>
     /// Gets a value indicating whether the ATIS station is an FAA ATIS station.
     /// </summary>
     [JsonIgnore]
@@ -237,6 +242,7 @@ public class AtisStation : ReactiveObject
             Contractions = Contractions.Select(x => x.Clone()).ToList(),
             AirportConditionDefinitions = AirportConditionDefinitions.Select(x => x.Clone()).ToList(),
             NotamDefinitions = NotamDefinitions.Select(x => x.Clone()).ToList(),
+            DatisTextReplacements = DatisTextReplacements.Select(x => x.Clone()).ToList(),
         };
     }
 

--- a/vATIS.Desktop/Profiles/Models/DatisTextReplacement.cs
+++ b/vATIS.Desktop/Profiles/Models/DatisTextReplacement.cs
@@ -1,0 +1,41 @@
+// <copyright file="DatisTextReplacement.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Vatsim.Vatis.Profiles.Models;
+
+/// <summary>
+/// Represents a text replacement rule applied to D-ATIS data before display.
+/// </summary>
+public class DatisTextReplacement
+{
+    /// <summary>
+    /// Gets or sets the pattern to match in the D-ATIS text.
+    /// </summary>
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the replacement text to substitute for the matched pattern.
+    /// </summary>
+    public string Replacement { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the pattern should be treated as a regular expression.
+    /// </summary>
+    public bool IsRegex { get; set; }
+
+    /// <summary>
+    /// Creates a deep copy of the current <see cref="DatisTextReplacement"/> instance.
+    /// </summary>
+    /// <returns>A new <see cref="DatisTextReplacement"/> instance that is a copy of this instance.</returns>
+    public DatisTextReplacement Clone()
+    {
+        return new DatisTextReplacement
+        {
+            Pattern = Pattern,
+            Replacement = Replacement,
+            IsRegex = IsRegex,
+        };
+    }
+}

--- a/vATIS.Desktop/SourceGenerationContext.cs
+++ b/vATIS.Desktop/SourceGenerationContext.cs
@@ -68,6 +68,8 @@ namespace Vatsim.Vatis;
 [JsonSerializable(typeof(InstalledProfilesMessage))]
 [JsonSerializable(typeof(ActiveProfileMessage))]
 [JsonSerializable(typeof(List<ContractionsResponseMessage>))]
+[JsonSerializable(typeof(DatisTextReplacement))]
+[JsonSerializable(typeof(List<DatisTextReplacement>))]
 [JsonSerializable(typeof(DigitalAtisRequestDto))]
 [JsonSerializable(typeof(List<DigitalAtisResponseDto>))]
 [JsonSerializable(typeof(JsonElement))]

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
@@ -8,7 +8,7 @@
              x:Class="Vatsim.Vatis.Ui.AtisConfiguration.DatisReplacementsView">
 	<StackPanel Orientation="Vertical" Spacing="10">
 		<Border Background="#1E1E1E" BorderBrush="#646464" BorderThickness="1" CornerRadius="4" Padding="10">
-			<DataGrid x:Name="ReplacementsGrid" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="380" ItemsSource="{Binding Replacements, DataType=vm:DatisReplacementsViewModel}" SelectionMode="Extended" CellEditEnding="ReplacementsGrid_OnCellEditEnding">
+			<DataGrid x:Name="ReplacementsGrid" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="380" ItemsSource="{Binding Replacements, DataType=vm:DatisReplacementsViewModel}" SelectionMode="Single" CellEditEnding="ReplacementsGrid_OnCellEditEnding">
 				<DataGrid.Styles>
 					<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
 						<Setter Property="IsVisible" Value="False" />

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
@@ -12,7 +12,7 @@
 		<Grid ColumnDefinitions="*,10,*">
 			<StackPanel Grid.Column="0" Spacing="4">
 				<TextBlock Text="Prepend Airport Conditions:"/>
-				<TextBox Text="{Binding PrependAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to airport conditions">
+				<TextBox Text="{Binding PrependAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to airport conditions" LostFocus="TextBox_OnLostFocus">
 					<Interaction.Behaviors>
 						<behaviors:TextBoxUppercaseBehavior/>
 					</Interaction.Behaviors>
@@ -20,7 +20,7 @@
 			</StackPanel>
 			<StackPanel Grid.Column="2" Spacing="4">
 				<TextBlock Text="Append Airport Conditions:"/>
-				<TextBox Text="{Binding AppendAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to airport conditions">
+				<TextBox Text="{Binding AppendAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to airport conditions" LostFocus="TextBox_OnLostFocus">
 					<Interaction.Behaviors>
 						<behaviors:TextBoxUppercaseBehavior/>
 					</Interaction.Behaviors>
@@ -31,7 +31,7 @@
 		<Grid ColumnDefinitions="*,10,*">
 			<StackPanel Grid.Column="0" Spacing="4">
 				<TextBlock Text="Prepend NOTAMs:"/>
-				<TextBox Text="{Binding PrependNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to NOTAMs">
+				<TextBox Text="{Binding PrependNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to NOTAMs" LostFocus="TextBox_OnLostFocus">
 					<Interaction.Behaviors>
 						<behaviors:TextBoxUppercaseBehavior/>
 					</Interaction.Behaviors>
@@ -39,7 +39,7 @@
 			</StackPanel>
 			<StackPanel Grid.Column="2" Spacing="4">
 				<TextBlock Text="Append NOTAMs:"/>
-				<TextBox Text="{Binding AppendNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to NOTAMs">
+				<TextBox Text="{Binding AppendNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to NOTAMs" LostFocus="TextBox_OnLostFocus">
 					<Interaction.Behaviors>
 						<behaviors:TextBoxUppercaseBehavior/>
 					</Interaction.Behaviors>

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels.AtisConfiguration"
+             xmlns:models="clr-namespace:Vatsim.Vatis.Profiles.Models"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Vatsim.Vatis.Ui.AtisConfiguration.DatisReplacementsView">
+	<StackPanel Orientation="Vertical" Spacing="10">
+		<Border Background="#1E1E1E" BorderBrush="#646464" BorderThickness="1" CornerRadius="4" Padding="10">
+			<DataGrid x:Name="ReplacementsGrid" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="380" ItemsSource="{Binding Replacements, DataType=vm:DatisReplacementsViewModel}" SelectionMode="Extended" CellEditEnding="ReplacementsGrid_OnCellEditEnding">
+				<DataGrid.Styles>
+					<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
+						<Setter Property="IsVisible" Value="False" />
+					</Style>
+				</DataGrid.Styles>
+				<DataGrid.Columns>
+					<DataGridTextColumn Header="Pattern" Width="2*" IsReadOnly="False" Binding="{Binding Pattern, DataType=models:DatisTextReplacement}"/>
+					<DataGridTextColumn Header="Replacement" Width="2*" IsReadOnly="False" Binding="{Binding Replacement, DataType=models:DatisTextReplacement}"/>
+					<DataGridCheckBoxColumn Header="Regex" Width="80" IsReadOnly="False" Binding="{Binding IsRegex, DataType=models:DatisTextReplacement}"/>
+				</DataGrid.Columns>
+			</DataGrid>
+		</Border>
+		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="5">
+			<Button Theme="{StaticResource Dark}" MinWidth="80" Height="28" Command="{Binding AddReplacementCommand, DataType=vm:DatisReplacementsViewModel}">New</Button>
+			<Button Theme="{StaticResource Dark}" Height="28" MinWidth="80" Command="{Binding DeleteReplacementCommand, DataType=vm:DatisReplacementsViewModel}" IsEnabled="{Binding #ReplacementsGrid.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" CommandParameter="{Binding #ReplacementsGrid.SelectedItem}">Delete</Button>
+		</StackPanel>
+	</StackPanel>
+</UserControl>

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml
@@ -4,11 +4,51 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Vatsim.Vatis.Ui.ViewModels.AtisConfiguration"
              xmlns:models="clr-namespace:Vatsim.Vatis.Profiles.Models"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:behaviors="using:Vatsim.Vatis.Ui.Behaviors"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="550"
              x:Class="Vatsim.Vatis.Ui.AtisConfiguration.DatisReplacementsView">
 	<StackPanel Orientation="Vertical" Spacing="10">
+		<!-- Prepend/Append Airport Conditions -->
+		<Grid ColumnDefinitions="*,10,*">
+			<StackPanel Grid.Column="0" Spacing="4">
+				<TextBlock Text="Prepend Airport Conditions:"/>
+				<TextBox Text="{Binding PrependAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to airport conditions">
+					<Interaction.Behaviors>
+						<behaviors:TextBoxUppercaseBehavior/>
+					</Interaction.Behaviors>
+				</TextBox>
+			</StackPanel>
+			<StackPanel Grid.Column="2" Spacing="4">
+				<TextBlock Text="Append Airport Conditions:"/>
+				<TextBox Text="{Binding AppendAirportConditions, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to airport conditions">
+					<Interaction.Behaviors>
+						<behaviors:TextBoxUppercaseBehavior/>
+					</Interaction.Behaviors>
+				</TextBox>
+			</StackPanel>
+		</Grid>
+		<!-- Prepend/Append NOTAMs -->
+		<Grid ColumnDefinitions="*,10,*">
+			<StackPanel Grid.Column="0" Spacing="4">
+				<TextBlock Text="Prepend NOTAMs:"/>
+				<TextBox Text="{Binding PrependNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to prepend to NOTAMs">
+					<Interaction.Behaviors>
+						<behaviors:TextBoxUppercaseBehavior/>
+					</Interaction.Behaviors>
+				</TextBox>
+			</StackPanel>
+			<StackPanel Grid.Column="2" Spacing="4">
+				<TextBlock Text="Append NOTAMs:"/>
+				<TextBox Text="{Binding AppendNotams, DataType=vm:DatisReplacementsViewModel}" Theme="{StaticResource DarkTextBox}" Watermark="Text to append to NOTAMs">
+					<Interaction.Behaviors>
+						<behaviors:TextBoxUppercaseBehavior/>
+					</Interaction.Behaviors>
+				</TextBox>
+			</StackPanel>
+		</Grid>
+		<!-- Text Replacements -->
 		<Border Background="#1E1E1E" BorderBrush="#646464" BorderThickness="1" CornerRadius="4" Padding="10">
-			<DataGrid x:Name="ReplacementsGrid" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="380" ItemsSource="{Binding Replacements, DataType=vm:DatisReplacementsViewModel}" SelectionMode="Single" CellEditEnding="ReplacementsGrid_OnCellEditEnding">
+			<DataGrid x:Name="ReplacementsGrid" GridLinesVisibility="All" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="False" BorderThickness="1" BorderBrush="#646464" Height="280" ItemsSource="{Binding Replacements, DataType=vm:DatisReplacementsViewModel}" SelectionMode="Single" CellEditEnding="ReplacementsGrid_OnCellEditEnding">
 				<DataGrid.Styles>
 					<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
 						<Setter Property="IsVisible" Value="False" />

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml.cs
@@ -1,0 +1,32 @@
+// <copyright file="DatisReplacementsView.axaml.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using Avalonia.Controls;
+using Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
+
+namespace Vatsim.Vatis.Ui.AtisConfiguration;
+
+/// <summary>
+/// Represents the view for displaying and managing D-ATIS text replacement rules.
+/// </summary>
+public partial class DatisReplacementsView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatisReplacementsView"/> class.
+    /// </summary>
+    public DatisReplacementsView()
+    {
+        InitializeComponent();
+    }
+
+    private void ReplacementsGrid_OnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+    {
+        if (e.EditAction == DataGridEditAction.Commit && DataContext is DatisReplacementsViewModel vm)
+        {
+            vm.CellEditEndingCommand.Execute().Subscribe();
+        }
+    }
+}

--- a/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml.cs
+++ b/vATIS.Desktop/Ui/AtisConfiguration/DatisReplacementsView.axaml.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 
 namespace Vatsim.Vatis.Ui.AtisConfiguration;
@@ -27,6 +28,14 @@ public partial class DatisReplacementsView : UserControl
         if (e.EditAction == DataGridEditAction.Commit && DataContext is DatisReplacementsViewModel vm)
         {
             vm.CellEditEndingCommand.Execute().Subscribe();
+        }
+    }
+
+    private void TextBox_OnLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is DatisReplacementsViewModel vm)
+        {
+            vm.TextBoxLostFocusCommand.Execute().Subscribe();
         }
     }
 }

--- a/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
+++ b/vATIS.Desktop/Ui/Dialogs/SettingsDialog.axaml
@@ -46,7 +46,8 @@
 				<StackPanel>
 					<CheckBox Theme="{StaticResource CheckBox}" Content="Mute own ATIS update sound" IsChecked="{Binding MuteOwnAtisUpdateSound, DataType=vm:SettingsDialogViewModel}" />
                     <CheckBox Theme="{StaticResource CheckBox}" Content="Mute shared ATIS update sound" IsChecked="{Binding MuteSharedAtisUpdateSound, DataType=vm:SettingsDialogViewModel}" />
-					<CheckBox Theme="{StaticResource CheckBox}" Content="Automatically fetch ATIS letter" ToolTip.Tip="Fetch the real-world ATIS letter for supported stations automatically after connecting to the network." IsChecked="{Binding AutoFetchAtisLetter, DataType=vm:SettingsDialogViewModel}" />
+					<CheckBox Theme="{StaticResource CheckBox}" Content="Automatically fetch ATIS letter" ToolTip.Tip="Fetch the real-world ATIS letter for supported stations automatically after connecting to the network." IsChecked="{Binding AutoFetchAtisLetter, DataType=vm:SettingsDialogViewModel}" IsEnabled="{Binding !AutoFetchDatis, DataType=vm:SettingsDialogViewModel}" />
+					<CheckBox Theme="{StaticResource CheckBox}" Content="Automatically fetch D-ATIS" ToolTip.Tip="Fetch real-world D-ATIS data and populate airport conditions and NOTAMs for stations with a D-ATIS preset." IsChecked="{Binding AutoFetchDatis, DataType=vm:SettingsDialogViewModel}" />
 				</StackPanel>
 				<Grid ColumnDefinitions="1*,5,1*">
 					<Button Theme="{StaticResource Dark}" Grid.Column="0" HorizontalAlignment="Stretch" Content="Save" Command="{Binding SaveSettingsCommand, DataType=vm:SettingsDialogViewModel}" CommandParameter="{Binding ElementName=Window}" IsDefault="True" />

--- a/vATIS.Desktop/Ui/IViewModelFactory.cs
+++ b/vATIS.Desktop/Ui/IViewModelFactory.cs
@@ -53,4 +53,10 @@ public interface IViewModelFactory
     /// </summary>
     /// <returns>A new instance of <see ref="SandboxViewModel"/>.</returns>
     SandboxViewModel CreateSandboxViewModel();
+
+    /// <summary>
+    /// Creates an instance of <see cref="DatisReplacementsViewModel"/> for managing D-ATIS text replacement rules.
+    /// </summary>
+    /// <returns>A new instance of <see cref="DatisReplacementsViewModel"/>.</returns>
+    DatisReplacementsViewModel CreateDatisReplacementsViewModel();
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
@@ -1,0 +1,137 @@
+// <copyright file="DatisReplacementsViewModel.cs" company="Justin Shannon">
+// Copyright (c) Justin Shannon. All rights reserved.
+// Licensed under the GPLv3 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using ReactiveUI;
+using Vatsim.Vatis.Config;
+using Vatsim.Vatis.Profiles.Models;
+
+namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
+
+/// <summary>
+/// Provides a view model for managing D-ATIS text replacement rules within the ATIS configuration.
+/// </summary>
+public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly IAppConfig _appConfig;
+    private AtisStation? _selectedStation;
+    private ObservableCollection<DatisTextReplacement>? _replacements;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatisReplacementsViewModel"/> class.
+    /// </summary>
+    /// <param name="appConfig">The application configuration.</param>
+    public DatisReplacementsViewModel(IAppConfig appConfig)
+    {
+        _appConfig = appConfig;
+
+        AtisStationChanged = ReactiveCommand.Create<AtisStation>(HandleAtisStationChanged);
+        AddReplacementCommand = ReactiveCommand.Create(HandleAddReplacement);
+        DeleteReplacementCommand = ReactiveCommand.Create<DatisTextReplacement>(HandleDeleteReplacement);
+        CellEditEndingCommand = ReactiveCommand.Create(HandleCellEditEnding);
+
+        _disposables.Add(AtisStationChanged);
+        _disposables.Add(AddReplacementCommand);
+        _disposables.Add(DeleteReplacementCommand);
+        _disposables.Add(CellEditEndingCommand);
+    }
+
+    /// <summary>
+    /// Gets the command to handle changes to the ATIS station.
+    /// </summary>
+    public ReactiveCommand<AtisStation, Unit> AtisStationChanged { get; }
+
+    /// <summary>
+    /// Gets the command to add a new replacement rule.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> AddReplacementCommand { get; }
+
+    /// <summary>
+    /// Gets the command to delete a replacement rule.
+    /// </summary>
+    public ReactiveCommand<DatisTextReplacement, Unit> DeleteReplacementCommand { get; }
+
+    /// <summary>
+    /// Gets the command executed when a cell edit operation ends.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> CellEditEndingCommand { get; }
+
+    /// <summary>
+    /// Gets or sets the currently selected ATIS station.
+    /// </summary>
+    public AtisStation? SelectedStation
+    {
+        get => _selectedStation;
+        set => this.RaiseAndSetIfChanged(ref _selectedStation, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the collection of D-ATIS text replacement rules.
+    /// </summary>
+    public ObservableCollection<DatisTextReplacement>? Replacements
+    {
+        get => _replacements;
+        set => this.RaiseAndSetIfChanged(ref _replacements, value);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _disposables.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void HandleAtisStationChanged(AtisStation? station)
+    {
+        if (station == null)
+        {
+            return;
+        }
+
+        SelectedStation = station;
+        Replacements = new ObservableCollection<DatisTextReplacement>(station.DatisTextReplacements);
+    }
+
+    private void HandleAddReplacement()
+    {
+        if (SelectedStation == null || Replacements == null)
+        {
+            return;
+        }
+
+        var replacement = new DatisTextReplacement();
+        SelectedStation.DatisTextReplacements.Add(replacement);
+        Replacements.Add(replacement);
+        _appConfig.SaveConfig();
+    }
+
+    private void HandleDeleteReplacement(DatisTextReplacement? item)
+    {
+        if (item == null || SelectedStation == null || Replacements == null)
+        {
+            return;
+        }
+
+        if (Replacements.Remove(item))
+        {
+            SelectedStation.DatisTextReplacements.Remove(item);
+            _appConfig.SaveConfig();
+        }
+    }
+
+    private void HandleCellEditEnding()
+    {
+        if (SelectedStation == null)
+        {
+            return;
+        }
+
+        _appConfig.SaveConfig();
+    }
+}

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
@@ -8,8 +8,9 @@ using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Disposables;
 using ReactiveUI;
-using Vatsim.Vatis.Config;
+using Vatsim.Vatis.Profiles;
 using Vatsim.Vatis.Profiles.Models;
+using Vatsim.Vatis.Sessions;
 
 namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 
@@ -19,17 +20,20 @@ namespace Vatsim.Vatis.Ui.ViewModels.AtisConfiguration;
 public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
 {
     private readonly CompositeDisposable _disposables = [];
-    private readonly IAppConfig _appConfig;
+    private readonly IProfileRepository _profileRepository;
+    private readonly ISessionManager _sessionManager;
     private AtisStation? _selectedStation;
     private ObservableCollection<DatisTextReplacement>? _replacements;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DatisReplacementsViewModel"/> class.
     /// </summary>
-    /// <param name="appConfig">The application configuration.</param>
-    public DatisReplacementsViewModel(IAppConfig appConfig)
+    /// <param name="profileRepository">The profile repository used to persist profile data.</param>
+    /// <param name="sessionManager">The session manager for accessing the current profile.</param>
+    public DatisReplacementsViewModel(IProfileRepository profileRepository, ISessionManager sessionManager)
     {
-        _appConfig = appConfig;
+        _profileRepository = profileRepository;
+        _sessionManager = sessionManager;
 
         AtisStationChanged = ReactiveCommand.Create<AtisStation>(HandleAtisStationChanged);
         AddReplacementCommand = ReactiveCommand.Create(HandleAddReplacement);
@@ -87,6 +91,14 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
         GC.SuppressFinalize(this);
     }
 
+    private void SaveProfile()
+    {
+        if (_sessionManager.CurrentProfile != null)
+        {
+            _profileRepository.Save(_sessionManager.CurrentProfile);
+        }
+    }
+
     private void HandleAtisStationChanged(AtisStation? station)
     {
         if (station == null)
@@ -108,7 +120,7 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
         var replacement = new DatisTextReplacement();
         SelectedStation.DatisTextReplacements.Add(replacement);
         Replacements.Add(replacement);
-        _appConfig.SaveConfig();
+        SaveProfile();
     }
 
     private void HandleDeleteReplacement(DatisTextReplacement? item)
@@ -121,7 +133,7 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
         if (Replacements.Remove(item))
         {
             SelectedStation.DatisTextReplacements.Remove(item);
-            _appConfig.SaveConfig();
+            SaveProfile();
         }
     }
 
@@ -132,6 +144,6 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             return;
         }
 
-        _appConfig.SaveConfig();
+        SaveProfile();
     }
 }

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
@@ -24,6 +24,10 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
     private readonly ISessionManager _sessionManager;
     private AtisStation? _selectedStation;
     private ObservableCollection<DatisTextReplacement>? _replacements;
+    private string _prependAirportConditions = string.Empty;
+    private string _appendAirportConditions = string.Empty;
+    private string _prependNotams = string.Empty;
+    private string _appendNotams = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DatisReplacementsViewModel"/> class.
@@ -84,6 +88,74 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref _replacements, value);
     }
 
+    /// <summary>
+    /// Gets or sets text to prepend to D-ATIS airport conditions.
+    /// </summary>
+    public string PrependAirportConditions
+    {
+        get => _prependAirportConditions;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _prependAirportConditions, value);
+            if (SelectedStation != null)
+            {
+                SelectedStation.DatisPrependAirportConditions = value;
+                SaveProfile();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets text to append to D-ATIS airport conditions.
+    /// </summary>
+    public string AppendAirportConditions
+    {
+        get => _appendAirportConditions;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _appendAirportConditions, value);
+            if (SelectedStation != null)
+            {
+                SelectedStation.DatisAppendAirportConditions = value;
+                SaveProfile();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets text to prepend to D-ATIS NOTAMs.
+    /// </summary>
+    public string PrependNotams
+    {
+        get => _prependNotams;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _prependNotams, value);
+            if (SelectedStation != null)
+            {
+                SelectedStation.DatisPrependNotams = value;
+                SaveProfile();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets text to append to D-ATIS NOTAMs.
+    /// </summary>
+    public string AppendNotams
+    {
+        get => _appendNotams;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _appendNotams, value);
+            if (SelectedStation != null)
+            {
+                SelectedStation.DatisAppendNotams = value;
+                SaveProfile();
+            }
+        }
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -108,6 +180,14 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
 
         SelectedStation = station;
         Replacements = new ObservableCollection<DatisTextReplacement>(station.DatisTextReplacements);
+        _prependAirportConditions = station.DatisPrependAirportConditions;
+        this.RaisePropertyChanged(nameof(PrependAirportConditions));
+        _appendAirportConditions = station.DatisAppendAirportConditions;
+        this.RaisePropertyChanged(nameof(AppendAirportConditions));
+        _prependNotams = station.DatisPrependNotams;
+        this.RaisePropertyChanged(nameof(PrependNotams));
+        _appendNotams = station.DatisAppendNotams;
+        this.RaisePropertyChanged(nameof(AppendNotams));
     }
 
     private void HandleAddReplacement()

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
@@ -43,11 +43,13 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
         AddReplacementCommand = ReactiveCommand.Create(HandleAddReplacement);
         DeleteReplacementCommand = ReactiveCommand.Create<DatisTextReplacement>(HandleDeleteReplacement);
         CellEditEndingCommand = ReactiveCommand.Create(HandleCellEditEnding);
+        TextBoxLostFocusCommand = ReactiveCommand.Create(HandleTextBoxLostFocus);
 
         _disposables.Add(AtisStationChanged);
         _disposables.Add(AddReplacementCommand);
         _disposables.Add(DeleteReplacementCommand);
         _disposables.Add(CellEditEndingCommand);
+        _disposables.Add(TextBoxLostFocusCommand);
     }
 
     /// <summary>
@@ -69,6 +71,11 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
     /// Gets the command executed when a cell edit operation ends.
     /// </summary>
     public ReactiveCommand<Unit, Unit> CellEditEndingCommand { get; }
+
+    /// <summary>
+    /// Gets the command executed when a prepend/append text box loses focus.
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> TextBoxLostFocusCommand { get; }
 
     /// <summary>
     /// Gets or sets the currently selected ATIS station.
@@ -100,7 +107,6 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             if (SelectedStation != null)
             {
                 SelectedStation.DatisPrependAirportConditions = value;
-                SaveProfile();
             }
         }
     }
@@ -117,7 +123,6 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             if (SelectedStation != null)
             {
                 SelectedStation.DatisAppendAirportConditions = value;
-                SaveProfile();
             }
         }
     }
@@ -134,7 +139,6 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             if (SelectedStation != null)
             {
                 SelectedStation.DatisPrependNotams = value;
-                SaveProfile();
             }
         }
     }
@@ -151,7 +155,6 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             if (SelectedStation != null)
             {
                 SelectedStation.DatisAppendNotams = value;
-                SaveProfile();
             }
         }
     }
@@ -218,6 +221,16 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
     }
 
     private void HandleCellEditEnding()
+    {
+        if (SelectedStation == null)
+        {
+            return;
+        }
+
+        SaveProfile();
+    }
+
+    private void HandleTextBoxLostFocus()
     {
         if (SelectedStation == null)
         {

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs
@@ -181,6 +181,11 @@ public class DatisReplacementsViewModel : ReactiveViewModelBase, IDisposable
             return;
         }
 
+        if (SelectedStation != null)
+        {
+            SaveProfile();
+        }
+
         SelectedStation = station;
         Replacements = new ObservableCollection<DatisTextReplacement>(station.DatisTextReplacements);
         _prependAirportConditions = station.DatisPrependAirportConditions;

--- a/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisConfigurationWindowViewModel.cs
@@ -170,6 +170,12 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
     public SandboxViewModel? SandboxViewModel { get; private set; }
 
     /// <summary>
+    /// Gets the instance of <see cref="DatisReplacementsViewModel"/> used for managing D-ATIS text
+    /// replacement rules in the ATIS configuration window.
+    /// </summary>
+    public DatisReplacementsViewModel? DatisReplacementsViewModel { get; private set; }
+
+    /// <summary>
     /// Gets the command that handles the logic to close a window that implements the <see cref="ICloseable"/> interface.
     /// </summary>
     public ReactiveCommand<ICloseable, Unit> CloseWindowCommand { get; }
@@ -310,11 +316,14 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         SandboxViewModel = _viewModelFactory.CreateSandboxViewModel();
         SandboxViewModel.DialogOwner = _dialogOwner;
 
+        DatisReplacementsViewModel = _viewModelFactory.CreateDatisReplacementsViewModel();
+
         _disposables.Add(GeneralConfigViewModel);
         _disposables.Add(PresetsViewModel);
         _disposables.Add(FormattingViewModel);
         _disposables.Add(ContractionsViewModel);
         _disposables.Add(SandboxViewModel);
+        _disposables.Add(DatisReplacementsViewModel);
     }
 
     /// <inheritdoc />
@@ -886,6 +895,7 @@ public class AtisConfigurationWindowViewModel : ReactiveViewModelBase, IDisposab
         FormattingViewModel?.AtisStationChanged.Execute(station).Subscribe();
         ContractionsViewModel?.AtisStationChanged.Execute(station).Subscribe();
         SandboxViewModel?.AtisStationChanged.Execute(station).Subscribe();
+        DatisReplacementsViewModel?.AtisStationChanged.Execute(station).Subscribe();
     }
 
     private void ResetFields()

--- a/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/AtisStationViewModel.cs
@@ -68,6 +68,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     private readonly IAtisHubConnection _atisHubConnection;
     private readonly IWebsocketService _websocketService;
     private readonly ISessionManager _sessionManager;
+    private readonly IDatisRepository _datisRepository;
     private readonly Airport _atisStationAirport;
     private readonly MetarDecoder _metarDecoder = new();
     private readonly CompositeDisposable _disposables = [];
@@ -150,11 +151,14 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// <param name="websocketService">
     /// The websocket service for handling websocket communications.
     /// </param>
+    /// <param name="datisRepository">
+    /// The D-ATIS repository for fetching real-world D-ATIS data.
+    /// </param>
     public AtisStationViewModel(AtisStation station, WindowNotificationManager? windowNotificationManager,
         INetworkConnectionFactory connectionFactory, IVoiceServerConnectionFactory voiceServerConnectionFactory,
         IAppConfig appConfig, IAtisBuilder atisBuilder, IWindowFactory windowFactory,
         INavDataRepository navDataRepository, IAtisHubConnection hubConnection, ISessionManager sessionManager,
-        IProfileRepository profileRepository, IWebsocketService websocketService)
+        IProfileRepository profileRepository, IWebsocketService websocketService, IDatisRepository datisRepository)
     {
         Id = station.Id;
         Identifier = station.Identifier;
@@ -167,6 +171,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
         _atisHubConnection = hubConnection;
         _sessionManager = sessionManager;
         _profileRepository = profileRepository;
+        _datisRepository = datisRepository;
         _atisStationAirport = navDataRepository.GetAirport(station.Identifier) ??
                               throw new ApplicationException($"{station.Identifier} not found in airport navdata.");
 
@@ -284,6 +289,38 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
             {
                 LoadContractionData();
             }
+        }));
+        _disposables.Add(EventBus.Instance.Subscribe<DatisReceived>(evt =>
+        {
+            if (evt.Result.StationId != AtisStation.Id)
+                return;
+
+            if (!_appConfig.AutoFetchDatis)
+                return;
+
+            if (SelectedAtisPreset == null ||
+                !string.Equals(SelectedAtisPreset.Name, "D-ATIS", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (AirportConditionsTextDocument != null)
+                {
+                    AirportConditionsTextDocument.Text = evt.Result.AirportConditions;
+                }
+
+                if (NotamsTextDocument != null)
+                {
+                    NotamsTextDocument.Text = evt.Result.Notams;
+                }
+
+                if (evt.Result.AtisLetter.HasValue)
+                {
+                    SetAtisLetterCommand.Execute(evt.Result.AtisLetter.Value).Subscribe();
+                }
+            });
         }));
         _disposables.Add(EventBus.Instance.Subscribe<AtisHubAtisReceived>(sync =>
         {
@@ -776,6 +813,7 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        _datisRepository.RemoveStation(AtisStation.Id);
         _disposables.Dispose();
 
         _websocketService.GetAtisReceived -= OnGetAtisReceived;
@@ -1634,6 +1672,13 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
                     }
                 }
 
+                // Stop D-ATIS monitoring if the previous preset was D-ATIS
+                if (_previousAtisPreset != null &&
+                    string.Equals(_previousAtisPreset.Name, "D-ATIS", StringComparison.OrdinalIgnoreCase))
+                {
+                    _datisRepository.RemoveStation(AtisStation.Id);
+                }
+
                 SelectedAtisPreset = preset;
                 _previousAtisPreset = preset;
 
@@ -1642,6 +1687,13 @@ public class AtisStationViewModel : ReactiveViewModelBase, IDisposable
 
                 HasUnsavedNotams = false;
                 HasUnsavedAirportConditions = false;
+
+                // Start D-ATIS monitoring if the setting is enabled and the new preset is D-ATIS
+                if (_appConfig.AutoFetchDatis &&
+                    string.Equals(preset.Name, "D-ATIS", StringComparison.OrdinalIgnoreCase))
+                {
+                    _datisRepository.MonitorStation(AtisStation);
+                }
 
                 if (NetworkConnectionStatus != NetworkConnectionStatus.Connected || _networkConnection == null)
                     return;

--- a/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
+++ b/vATIS.Desktop/Ui/ViewModels/SettingsDialogViewModel.cs
@@ -29,6 +29,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
     private bool _muteOwnAtisUpdateSound;
     private bool _muteSharedAtisUpdateSound;
     private bool _autoFetchAtisLetter;
+    private bool _autoFetchDatis;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SettingsDialogViewModel"/> class.
@@ -45,6 +46,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         MuteSharedAtisUpdateSound = _appConfig.MuteSharedAtisUpdateSound;
         SelectedNetworkRating = _appConfig.NetworkRating.ToString();
         AutoFetchAtisLetter = _appConfig.AutoFetchAtisLetter;
+        AutoFetchDatis = _appConfig.AutoFetchDatis;
 
         NetworkRatings =
         [
@@ -142,6 +144,23 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref _autoFetchAtisLetter, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically fetch and populate real-world D-ATIS data.
+    /// When enabled, <see cref="AutoFetchAtisLetter"/> is forced on.
+    /// </summary>
+    public bool AutoFetchDatis
+    {
+        get => _autoFetchDatis;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _autoFetchDatis, value);
+            if (value)
+            {
+                AutoFetchAtisLetter = true;
+            }
+        }
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -158,6 +177,7 @@ public class SettingsDialogViewModel : ReactiveViewModelBase, IDisposable
         _appConfig.MuteOwnAtisUpdateSound = MuteOwnAtisUpdateSound;
         _appConfig.MuteSharedAtisUpdateSound = MuteSharedAtisUpdateSound;
         _appConfig.AutoFetchAtisLetter = AutoFetchAtisLetter;
+        _appConfig.AutoFetchDatis = AutoFetchDatis;
 
         if (Enum.TryParse(SelectedNetworkRating, out NetworkRating selectedNetworkRating))
         {

--- a/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
+++ b/vATIS.Desktop/Ui/Windows/AtisConfigurationWindow.axaml
@@ -103,6 +103,9 @@
 						<TabItem Header="Sandbox">
 							<views:SandboxView DataContext="{Binding SandboxViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
 						</TabItem>
+						<TabItem Header="D-ATIS">
+							<views:DatisReplacementsView DataContext="{Binding DatisReplacementsViewModel, DataType=vm:AtisConfigurationWindowViewModel}"/>
+						</TabItem>
 					</TabControl>
 					<Grid ColumnDefinitions="1*,1*,1*" Grid.Column="0" Grid.Row="1">
 						<Button Command="{Binding NewAtisStationDialogCommand, DataType=vm:AtisConfigurationWindowViewModel}" Grid.Column="0" Margin="0,0,5,0" Theme="{StaticResource Dark}" Height="28" HorizontalAlignment="Stretch">New</Button>


### PR DESCRIPTION
## Summary

- Fetches real-world D-ATIS data from the existing Digital ATIS API, processes it, and populates airport conditions and NOTAMs fields when a station has a preset named "D-ATIS" selected
- Data refreshes every 5 minutes, eliminating the need for the external [vATISLoad](https://github.com/glott/vATISLoad) tool
- New "Automatically fetch D-ATIS" setting in User Settings controls the feature; when enabled, "Automatically fetch ATIS letter" is forced on
- Per-station text replacement rules (literal or regex) configurable via a new "D-ATIS" tab in ATIS Configuration, stored in profile JSON

## New files

| File | Purpose |
|------|---------|
| `Atis/DatisResult.cs` | Record: processed airport conditions, NOTAMs, ATIS letter |
| `Atis/IDatisTextProcessor.cs` / `DatisTextProcessor.cs` | Text processing pipeline (strip envelope, normalize NOTAMs, apply replacements, clean punctuation, expand contractions, split) |
| `Atis/IDatisRepository.cs` / `DatisRepository.cs` | Periodic fetcher (300s `DispatcherTimer`), publishes `DatisReceived` events |
| `Events/DatisReceived.cs` | EventBus event |
| `Profiles/Models/DatisTextReplacement.cs` | Model for replacement rules |
| `Ui/ViewModels/AtisConfiguration/DatisReplacementsViewModel.cs` | Config tab ViewModel |
| `Ui/AtisConfiguration/DatisReplacementsView.axaml(.cs)` | Config tab DataGrid UI |

## Modified files

| File | Change |
|------|--------|
| `AtisStation.cs` | Added `DatisTextReplacements` property + Clone |
| `SourceGenerationContext.cs` | Registered `DatisTextReplacement` types |
| `ServiceProvider.cs` | Registered `IDatisTextProcessor`, `IDatisRepository`, `DatisReplacementsViewModel` |
| `ViewModelFactory.cs` / `IViewModelFactory.cs` | Wired new dependencies |
| `AtisStationViewModel.cs` | Subscribes to `DatisReceived`, manages D-ATIS monitoring lifecycle |
| `AtisConfigurationWindowViewModel.cs` | Wired `DatisReplacementsViewModel` |
| `AtisConfigurationWindow.axaml` | Added "D-ATIS" tab |
| `IAppConfig.cs` / `AppConfig.cs` | Added `AutoFetchDatis` setting |
| `SettingsDialogViewModel.cs` | Added `AutoFetchDatis` with coupling to `AutoFetchAtisLetter` |
| `SettingsDialog.axaml` | Added "Automatically fetch D-ATIS" checkbox |

## Test plan

- [ ] Enable "Automatically fetch D-ATIS" in User Settings — verify "Automatically fetch ATIS letter" becomes checked and greyed out
- [ ] Create a station with a preset named "D-ATIS", select it — verify airport conditions and NOTAMs populate
- [ ] Wait 5 minutes — verify data refreshes
- [ ] Switch to a different preset — verify auto-loading stops
- [ ] Open ATIS Configuration → D-ATIS tab — add literal and regex replacement rules, verify they persist and apply
- [ ] Test station with no D-ATIS data available — should show "D-ATIS NOT AVBL."
- [ ] Disable the setting — verify D-ATIS presets behave like normal presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic D-ATIS fetching with periodic background updates and live population of airport conditions, NOTAMs and ATIS letters
  * Per-station configurable text processing: pattern/regex replacements, contraction expansion, and prepend/append options

* **UI**
  * New D-ATIS configuration tab for managing replacements and per-station prepend/append text

* **Settings**
  * "Automatically fetch D-ATIS" toggle (enabling it forces ATIS-letter fetch and disables the ATIS-letter toggle)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->