### PR TITLE
Introduce `--import-profile` CLI argument to import profile using file path

### DIFF
--- a/vATIS.Desktop/App.axaml.cs
+++ b/vATIS.Desktop/App.axaml.cs
@@ -229,7 +229,22 @@ public class App : Application
                 _startupWindow.Close();
 
                 var sessionManager = _serviceProvider.GetService<ISessionManager>();
-                if (arguments.TryGetValue("--profile", out var profileId))
+                if (arguments.TryGetValue("--import-profile", out var importProfilePath))
+                {
+                    try
+                    {
+                        Log.Information($"Launching vATIS with --import-profile {importProfilePath}");
+                        var importedProfile =
+                            await _serviceProvider.GetService<IProfileRepository>().ImportWithId(importProfilePath);
+                        await sessionManager.StartSession(importedProfile.Id);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, $"Failed to import profile from path {importProfilePath}");
+                        sessionManager.Run();
+                    }
+                }
+                else if (arguments.TryGetValue("--profile", out var profileId))
                 {
                     Log.Information($"Launching vATIS with --profile {profileId}");
                     await sessionManager.StartSession(profileId);

--- a/vATIS.Desktop/Profiles/IProfileRepository.cs
+++ b/vATIS.Desktop/Profiles/IProfileRepository.cs
@@ -61,6 +61,14 @@ public interface IProfileRepository
     Task<Profile> Import(string path);
 
     /// <summary>
+    /// Imports a profile from the specified file path, preserving the profile's existing identifier.
+    /// If a profile with the same identifier already exists, its content is overwritten.
+    /// </summary>
+    /// <param name="path">The file path to the profile to be imported.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the imported <see cref="Profile"/>.</returns>
+    Task<Profile> ImportWithId(string path);
+
+    /// <summary>
     /// Exports the specified profile to a file at the given path.
     /// </summary>
     /// <param name="profile">The profile to export.</param>

--- a/vATIS.Desktop/Profiles/ProfileRepository.cs
+++ b/vATIS.Desktop/Profiles/ProfileRepository.cs
@@ -181,7 +181,7 @@ public class ProfileRepository : IProfileRepository
     public async Task<Profile> ImportWithId(string path)
     {
         var profile = await Load(path);
-        if (string.IsNullOrEmpty(profile.Id))
+        if (string.IsNullOrWhiteSpace(profile.Id) || !Guid.TryParse(profile.Id, out _))
         {
             profile.Id = Guid.NewGuid().ToString();
         }

--- a/vATIS.Desktop/Profiles/ProfileRepository.cs
+++ b/vATIS.Desktop/Profiles/ProfileRepository.cs
@@ -178,6 +178,19 @@ public class ProfileRepository : IProfileRepository
     }
 
     /// <inheritdoc />
+    public async Task<Profile> ImportWithId(string path)
+    {
+        var profile = await Load(path);
+        if (string.IsNullOrEmpty(profile.Id))
+        {
+            profile.Id = Guid.NewGuid().ToString();
+        }
+        Log.Information($"Importing profile {profile.Name} ({profile.Id})");
+        Save(profile);
+        return profile;
+    }
+
+    /// <inheritdoc />
     public void Export(Profile profile, string path)
     {
         var scrubbed = JsonSerializer.Deserialize(


### PR DESCRIPTION
`--import-profile` imports profile, updates it if exists and opens it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing a profile from a file at startup via a command-line flag, using the imported profile as the initial session profile.
  * Extended profile import capabilities to preserve an existing profile identifier when importing (or generate one if missing/invalid).

* **Bug Fixes**
  * Improved startup resilience by falling back to the normal session start behavior if profile import/session initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->