### PR TITLE
Fix integration with vatSys

### DIFF
--- a/vATIS.Desktop/Networking/NetworkConnection.cs
+++ b/vATIS.Desktop/Networking/NetworkConnection.cs
@@ -356,7 +356,11 @@ public class NetworkConnection : INetworkConnection, IDisposable
                 ]));
                 break;
             case ClientQueryType.Atis:
-                var num = 0;
+                _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
+                    ["A", _atisStation?.AtisLetter.ToString() ?? string.Empty]));
+
+                var num = 1;
+
                 if (_atisStation != null && !string.IsNullOrEmpty(_atisStation.TextAtis))
                 {
                     var collection = FormatAtisText(_atisStation.TextAtis);
@@ -371,8 +375,6 @@ public class NetworkConnection : INetworkConnection, IDisposable
                 num++;
                 _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
                     ["E", num.ToString()]));
-                _fsdSession.SendPdu(new PDUClientQueryResponse(Callsign, e.Pdu.From, ClientQueryType.Atis,
-                    ["A", _atisStation?.AtisLetter.ToString() ?? string.Empty]));
 
                 break;
             case ClientQueryType.Inf:


### PR DESCRIPTION
vatSys currently is failing to display vATIS created ATIS due to what it deems an errant "A" line after the "E" line has been received. From discussion with the vatSys developer, he believes that vatSys should effectively ignore the "A" line and still process "T" lines to correctly display the ATIS if it is sent prior to the "E" line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ATIS responses now begin with the correct identifying letter before the text content.
  - ATIS line counts now start at 1, improving numbering accuracy and consistency.
  - Existing response ordering for text lines and completion counts remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->